### PR TITLE
Map styles - Switch to using satellite imagery

### DIFF
--- a/modules/map_backgrounds.py
+++ b/modules/map_backgrounds.py
@@ -1,3 +1,5 @@
+import streamlit as st
+
 MAP_BACKGROUNDS = {
     "Stadia": {
         "tiles": "https://tiles.stadiamaps.com/tiles/alidade_satellite/{z}/{x}/{y}{r}.jpg",
@@ -8,3 +10,18 @@ MAP_BACKGROUNDS = {
         "attribution": 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
     },
 }
+
+
+def map_style_selector() -> str:
+    """
+    Selector on the sidebar to change the map background.
+    Calling this method will add the selector to the sidebar.
+
+    :return:
+        Currently selected map style as string
+    """
+    return st.sidebar.selectbox(
+        "Select Map Style",
+        options=list(MAP_BACKGROUNDS.keys()),
+        index=0,
+    )

--- a/modules/map_backgrounds.py
+++ b/modules/map_backgrounds.py
@@ -1,0 +1,10 @@
+MAP_BACKGROUNDS = {
+    "Stadia": {
+        "tiles": "https://tiles.stadiamaps.com/tiles/alidade_satellite/{z}/{x}/{y}{r}.jpg",
+        "attribution": '&copy; CNES, Distribution Airbus DS, © Airbus DS, © PlanetObserver (Contains Copernicus Data) | &copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    },
+    "ESRI": {
+        "tiles": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+        "attribution": 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
+    },
+}

--- a/modules/plotting.py
+++ b/modules/plotting.py
@@ -6,6 +6,7 @@ from streamlit_folium import st_folium
 
 from database import LOCATIONS_TABLE
 from modules.database import get_table
+from modules.map_backgrounds import MAP_BACKGROUNDS
 
 LOCATIONS = get_table(LOCATIONS_TABLE)
 
@@ -19,10 +20,17 @@ def overview_map(map_style):
     :return:
         st_folium() map object
     """
+    map_style = MAP_BACKGROUNDS[map_style]
     glacier_sites = gpd.GeoDataFrame(
         LOCATIONS.execute(), geometry="geometry", crs="EPSG:4326"
     )
-    map = folium.Map(location=[72, -40], zoom_start=4, tiles=map_style)
+
+    map = folium.Map(
+        location=[72, -40],
+        zoom_start=4,
+        tiles=map_style["tiles"],
+        attr=map_style["attribution"],
+    )
 
     # Add markers to signify study sites:
     tooltip = folium.GeoJsonTooltip(

--- a/modules/ui_elements.py
+++ b/modules/ui_elements.py
@@ -126,16 +126,3 @@ def load_site_names(join_table) -> pd.DataFrame:
     ).execute()
 
 
-def map_style_selector():
-    """
-    Selector on the sidebar to change the map background.
-    Calling this method will add the selector to the sidebar.
-
-    :return:
-        Streamlit sidebar selectbox object
-    """
-    return st.sidebar.selectbox(
-        "Select Map Style",
-        options=list(MAP_BACKGROUNDS.keys()),
-        index=0,
-    )

--- a/modules/ui_elements.py
+++ b/modules/ui_elements.py
@@ -5,6 +5,7 @@ from ibis.expr.types import Table
 
 from database import LOCATIONS_TABLE
 from modules.database import get_table
+from modules.map_backgrounds import MAP_BACKGROUNDS
 from modules.shape_viewer import date_ranges_for_site
 
 LOCATIONS = get_table(LOCATIONS_TABLE)
@@ -123,3 +124,18 @@ def load_site_names(join_table) -> pd.DataFrame:
         .distinct()
         .order_by(ibis.asc(LOCATIONS.Glacier_ID))
     ).execute()
+
+
+def map_style_selector():
+    """
+    Selector on the sidebar to change the map background.
+    Calling this method will add the selector to the sidebar.
+
+    :return:
+        Streamlit sidebar selectbox object
+    """
+    return st.sidebar.selectbox(
+        "Select Map Style",
+        options=list(MAP_BACKGROUNDS.keys()),
+        index=0,
+    )

--- a/pages/Home.py
+++ b/pages/Home.py
@@ -1,6 +1,7 @@
 import streamlit as st
 
-from modules.plotting import overview_map, last_viewed_site
+from modules.plotting import last_viewed_site, overview_map
+from modules.ui_elements import map_style_selector
 
 st.html(
     """
@@ -22,12 +23,7 @@ st.text(
     "easy access to iceberg identification, metrics, and imagery."
 )
 
-# You can alter the map properties here:
-map_style = st.sidebar.selectbox(
-    "Select Map Style",
-    options=["CartoDB positron", "CartoDB dark_matter"],
-    index=0,  # This line sets the default, change to 1 for dark_matter default.
-)
+map_style = map_style_selector()
 st.sidebar.info(
     "ICE-AGE will be under steady development and the data updated continuously! "
     "The Data will be archived at the Arctic Data Center and web app source code is "

--- a/pages/Home.py
+++ b/pages/Home.py
@@ -1,7 +1,7 @@
 import streamlit as st
 
+from modules.map_backgrounds import map_style_selector
 from modules.plotting import last_viewed_site, overview_map
-from modules.ui_elements import map_style_selector
 
 st.html(
     """


### PR DESCRIPTION
Change the background map on the Home page to use satellite imagery. Also creates a shared module for the map style selector to re-use on the shape viewer.

Part of #13