### PR TITLE
Overview map - Indicate which glacier sites have data

### DIFF
--- a/modules/plotting.py
+++ b/modules/plotting.py
@@ -1,13 +1,66 @@
 import colorcet as cc
 import folium
 import geopandas as gpd
+import streamlit as st
 from shapely.geometry import box
 from streamlit_folium import st_folium
 
-from database import LOCATIONS_TABLE
-from modules.database import db_table
 from modules.map_backgrounds import MAP_BACKGROUNDS
+from modules.shape_viewer import locations_with_shape
 
+
+def map_overlay_css():
+    return st.markdown(
+        """
+        <style>
+        .st-key-glacier-map-container {
+            position: relative;
+        }
+        .st-key-glacier-map {
+            width: 100%;
+        }
+        .st-key-glacier-options {
+            position: absolute !important;
+            top: 20px;
+            right: 20px;
+            z-index: 1000; /* Must be higher than Folium's layers */
+            width: 300px;
+            
+            /* UI Styling */
+            background-color: white;
+            padding: 15px;
+            border-radius: 8px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+            border: 1px solid #ddd;
+            font-family: "Inter", "Segoe UI", Helvetica, Arial, sans-serif !important;
+            color: #31333F;
+        }
+        
+        .st-key-shapes-button button,
+        .st-key-statistics-button button {
+            background-color: #0047AB !important; /* Cobalt Blue */
+            color: white !important;
+            border: none !important;
+            border-radius: 8px !important;
+            padding: 0.6rem 1rem !important;
+            font-weight: 500 !important;
+            font-size: 16px !important;
+            letter-spacing: 0.3px !important;
+            transition: all 0.2s ease-in-out !important;
+        }
+
+        /* 3. Hover Effect */
+        .st-key-statistics-button button:hover,
+        .st-key-shapes-button button:hover {
+            background-color: #003380 !important;
+            transform: translateY(-1px); /* Subtle lift on hover */
+            box-shadow: 0 4px 8px rgba(0, 71, 171, 0.3) !important;
+        }
+        
+        /* 4. Heading Adjustment for Overlay */
+        </style>
+    """, unsafe_allow_html=True
+    )
 
 def overview_map(map_style):
     """
@@ -20,47 +73,62 @@ def overview_map(map_style):
     """
     map_style = MAP_BACKGROUNDS[map_style]
     glacier_sites = gpd.GeoDataFrame(
-        db_table(LOCATIONS_TABLE).execute(), geometry="geometry", crs="EPSG:4326"
+        locations_with_shape(), geometry="geometry", crs="EPSG:4326"
     )
 
     map = folium.Map(
-        location=[72, -40],
-        zoom_start=4,
         tiles=map_style["tiles"],
         attr=map_style["attribution"],
     )
+    minx, miny, maxx, maxy = glacier_sites.total_bounds.tolist()
+    map.fit_bounds([[miny, minx], [maxy, maxx]])
 
-    # Add markers to signify study sites:
-    tooltip = folium.GeoJsonTooltip(
-        fields=["Official_name"],
-        aliases=["Name"],
-        localize=True,
-        sticky=False,
-        labels=True,
-        style="""
-            background-color: #F0EFEF;
-            border: 2px solid black;
-            border-radius: 3px;
-            box-shadow: 3px;
-        """,
-        max_width=400,
-    )
+    # Color each marker based on data availability in the database
+    # Grey: None
+    # Blue: Either shapes or statistics
+    marker_js = """
+    function(feature, latlng) {
+        var color = feature.properties.has_shapes ? 'blue' : 'gray';
+        if (color == 'grey') {
+            color = feature.properties.has_statistics ? 'blue' : 'gray';
+        };
+        return L.marker(latlng, {
+            icon: L.AwesomeMarkers.icon({
+                icon: 'star',
+                markerColor: color,
+                prefix: 'fa',
+                iconColor: 'white'
+            })
+        });
+    }
+    """
+
     folium.GeoJson(
         glacier_sites,
-        name="Iceberg Study Sites",
+        tooltip=folium.GeoJsonTooltip(
+            fields=["Official_name"],
+            aliases=["Name"],
+            localize=True,
+            sticky=False,
+            labels=True,
+            style="""
+                background-color: #F0EFEF;
+                border: 2px solid black;
+                border-radius: 3px;
+                box-shadow: 3px;
+            """,
+        ),
+        point_to_layer=folium.utilities.JsCode(marker_js),
         marker=folium.Marker(icon=folium.Icon(icon="star")),
-        tooltip=tooltip,
     ).add_to(map)
 
-    return st_folium(
-        map, use_container_width=True, returned_objects=["last_active_drawing"]
-    )
+    return st_folium(map, use_container_width=True)
 
 
 def last_viewed_site(map_click):
     map_click = map_click.get("last_active_drawing", {})
     if map_click:
-        return map_click.get("properties", {}).get("Glacier_ID")
+        return map_click.get("properties", {})
     else:
         return None
 

--- a/modules/plotting.py
+++ b/modules/plotting.py
@@ -10,6 +10,12 @@ from modules.shape_viewer import locations_with_shape
 
 
 def map_overlay_css():
+    """
+    Add CSS styling for glacier map overlay controls.
+
+    :return:
+        st.markdown object with CSS info
+    """
     return st.markdown(
         """
         <style>
@@ -62,9 +68,10 @@ def map_overlay_css():
     """, unsafe_allow_html=True
     )
 
-def overview_map(map_style):
+
+def overview_map(map_style: str) -> dict:
     """
-    Overview map on the "Home" page
+    Create overview map for the Home page.
 
     :param map_style: User selected map style
 
@@ -125,7 +132,15 @@ def overview_map(map_style):
     return st_folium(map, use_container_width=True)
 
 
-def last_viewed_site(map_click):
+def last_viewed_site(map_click: dict) -> dict | None:
+    """
+    Extract site properties from the last clicked map feature.
+
+    :param map_click: Map interaction data from st_folium
+
+    :return:
+        Dictionary with site properties or None if no feature was clicked
+    """
     map_click = map_click.get("last_active_drawing", {})
     if map_click:
         return map_click.get("properties", {})
@@ -133,7 +148,7 @@ def last_viewed_site(map_click):
         return None
 
 
-def shape_color(map_element, color_map: dict) -> dict:
+def shape_color(map_element: dict, color_map: dict) -> dict:
     """
     Select a unique color for each iceberg from the color map.
 
@@ -144,7 +159,9 @@ def shape_color(map_element, color_map: dict) -> dict:
         Dictionary with style settings for the map element
     """
     iceberg_id = map_element["properties"]["IcebergID"]
-    # Show the date combinations with different styles. The early date has 0 as date_rank
+
+    # Show the date combinations with different styles.
+    # The early date has 0 as date_rank
     if map_element["properties"]["date_rank"] == 0:
         line_color = "black"
         opacity = 0.7
@@ -164,7 +181,7 @@ def shape_color(map_element, color_map: dict) -> dict:
 
 def unique_colors(iceberg_sites: gpd.GeoDataFrame) -> dict:
     """
-    Create a unique color for each iceberg
+    Create a unique color for each iceberg.
 
     :param iceberg_sites: GeoDataFrame with icebergs
 
@@ -176,9 +193,9 @@ def unique_colors(iceberg_sites: gpd.GeoDataFrame) -> dict:
     return {ice_id: palette[index] for index, ice_id in enumerate(iceberg_ids)}
 
 
-def iceberg_map(iceberg_sites: gpd.GeoDataFrame):
+def iceberg_map(iceberg_sites: gpd.GeoDataFrame) -> folium.Map:
     """
-    Create map with icebergs shapes
+    Create map with iceberg shapes.
 
     :param iceberg_sites: GeoDataFrame with icebergs to show in the map
 

--- a/modules/shape_viewer.py
+++ b/modules/shape_viewer.py
@@ -5,9 +5,31 @@ import streamlit as st
 from ibis import _
 from ibis import selectors as s
 
-from database import SHAPE_TABLE
+from database import LOCATIONS_TABLE, MELT_RATES_TABLE, SHAPE_TABLE
 from modules import DATE_FORMAT
 from modules.database import db_table
+
+
+def locations_with_shape() -> pd.DataFrame:
+    """
+    Return a Pandas DataFrame of all locations with a column to indicate if shapes
+    are available for that location.
+
+    :return:
+        DataFrame with locations and shape availability
+    """
+    return (
+        db_table(LOCATIONS_TABLE)
+        .mutate(
+            has_shapes=db_table(LOCATIONS_TABLE).Glacier_ID.isin(
+                db_table(SHAPE_TABLE).SiteID
+            ),
+            has_statistics=db_table(LOCATIONS_TABLE).Glacier_ID.isin(
+                db_table(MELT_RATES_TABLE).SiteID
+            ),
+        )
+        .execute()
+    )
 
 
 def date_ranges_for_site(site_id: str) -> pd.DataFrame:

--- a/modules/shape_viewer.py
+++ b/modules/shape_viewer.py
@@ -42,7 +42,8 @@ def date_ranges_for_site(site_id: str) -> pd.DataFrame:
         Dataframe with start and end dates
     """
     return (
-        db_table(SHAPE_TABLE).filter(db_table(SHAPE_TABLE).SiteID == site_id)
+        db_table(SHAPE_TABLE)
+        .filter(db_table(SHAPE_TABLE).SiteID == site_id)
         .group_by(db_table(SHAPE_TABLE).IcebergID, db_table(SHAPE_TABLE).filename)
         .aggregate(
             start=db_table(SHAPE_TABLE).Date.min(),
@@ -77,10 +78,14 @@ def map_data(site_select: dict, date_select: dict = None) -> gpd.GeoDataFrame:
         )
 
     window = ibis.window(group_by=[_.IcebergID, _.filename], order_by=_.Date)
-    shape_query = db_table(SHAPE_TABLE).filter(user_selection).select(
-        ~s.cols("Date", "filename"),
-        date_rank=ibis.row_number().over(window),
-        observed_date=db_table(SHAPE_TABLE).Date.strftime(DATE_FORMAT)
+    shape_query = (
+        db_table(SHAPE_TABLE)
+        .filter(user_selection)
+        .select(
+            ~s.cols("Date", "filename"),
+            date_rank=ibis.row_number().over(window),
+            observed_date=db_table(SHAPE_TABLE).Date.strftime(DATE_FORMAT),
+        )
     )
 
     return shape_query.to_pandas().set_crs("EPSG:3413")

--- a/pages/Home.py
+++ b/pages/Home.py
@@ -4,6 +4,15 @@ from modules.database import db_exists
 from modules.map_backgrounds import map_style_selector
 from modules.plotting import last_viewed_site, map_overlay_css, overview_map
 
+st.markdown(
+    """
+    <style>
+    @import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css');
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
 st.html(
     """
     <h1 style="
@@ -36,16 +45,17 @@ if db_exists():
             if map_click:
                 site = last_viewed_site(map_click)
                 if site:
-                    st.markdown(f"__Name__: {site["Official_name"]}")
+                    st.markdown(f"__Name__: {site['Official_name']}")
 
-                    if site.get("has_shapes", False) or site.get("has_statistics", False):
+                    if site.get("has_shapes", False) or site.get(
+                        "has_statistics", False
+                    ):
                         if st.button(
-                                "View Shapes", use_container_width=True,
-                                key="shapes-button"
+                            "View Shapes", use_container_width=True, key="shapes-button"
                         ):
                             st.switch_page(
                                 "pages/Iceberg-Viewer.py",
-                                query_params={"site_id": site["Glacier_ID"]}
+                                query_params={"site_id": site["Glacier_ID"]},
                             )
                         # TODO: Issue#11
                         # if st.button(
@@ -57,7 +67,16 @@ if db_exists():
                         #         query_params={"site_id": site["Glacier_ID"]}
                         #     )
                 else:
-                    st.text("Select a glacier site to see options.")
+                    st.markdown("""
+                    Select a glacier site to see options.
+                    
+                    **Map Legend:**
+                    """)
+                    with st.container(key="legend"):
+                        st.html(
+                            '<i class="fa-solid fa-map-marker" style="color: #0047AB; margin-right: 8px;"></i>Data available<br>'
+                            '<i class="fa-solid fa-map-marker" style="color: #808080; margin-right: 8px;"></i>No data available'
+                        )
 else:
     st.header("Setup instructions", divider=True)
     st.text(

--- a/pages/Home.py
+++ b/pages/Home.py
@@ -2,7 +2,7 @@ import streamlit as st
 
 from modules.database import db_exists
 from modules.map_backgrounds import map_style_selector
-from modules.plotting import last_viewed_site, overview_map
+from modules.plotting import last_viewed_site, map_overlay_css, overview_map
 
 st.html(
     """
@@ -25,13 +25,39 @@ st.text(
 
 if db_exists():
     st.header("Study Sites in Greenland", divider=True)
+    map_overlay_css()
     map_style = map_style_selector()
-    map_click = overview_map(map_style)
 
-    if map_click:
-        site = last_viewed_site(map_click)
-        if site:
-            st.switch_page("pages/Iceberg-Viewer.py", query_params={"site_id": site})
+    with st.container(key="glacier-map-container"):
+        with st.container(key="glacier-map"):
+            map_click = overview_map(map_style)
+
+        with st.container(key="glacier-options"):
+            if map_click:
+                site = last_viewed_site(map_click)
+                if site:
+                    st.markdown(f"__Name__: {site["Official_name"]}")
+
+                    if site.get("has_shapes", False) or site.get("has_statistics", False):
+                        if st.button(
+                                "View Shapes", use_container_width=True,
+                                key="shapes-button"
+                        ):
+                            st.switch_page(
+                                "pages/Iceberg-Viewer.py",
+                                query_params={"site_id": site["Glacier_ID"]}
+                            )
+                        # TODO: Issue#11
+                        # if st.button(
+                        #         "Show Statistics", use_container_width=True,
+                        #         key="statistics-button"
+                        # ):
+                        #     st.switch_page(
+                        #         "pages/Statistics-dashboard.py",
+                        #         query_params={"site_id": site["Glacier_ID"]}
+                        #     )
+                else:
+                    st.text("Select a glacier site to see options.")
 else:
     st.header("Setup instructions", divider=True)
     st.text(


### PR DESCRIPTION
Commit message:
Change the UI to show glacier sites without data as grey markers and sites with in blue.
Clicking on one marker now opens an overlay that shows a button to navigate to the shapes.
This prepares adding the option to also jump to the statistics dashboard via button.


Closes #10
Prepares #11