### PR TITLE
Shape Viewer - Show distances between matching observation pairs

### DIFF
--- a/modules/plotting.py
+++ b/modules/plotting.py
@@ -6,7 +6,7 @@ from shapely.geometry import box
 from streamlit_folium import st_folium
 
 from modules.map_backgrounds import MAP_BACKGROUNDS
-from modules.shape_viewer import locations_with_shape
+from modules.shape_viewer import locations_with_shape, shape_distances
 
 
 def map_overlay_css():
@@ -204,6 +204,7 @@ def iceberg_map(iceberg_sites: gpd.GeoDataFrame) -> folium.Map:
     :return:
         Folium map object
     """
+    site_lines = shape_distances(iceberg_sites)
     iceberg_sites.to_crs("EPSG:4326", inplace=True)
 
     map_center = box(*iceberg_sites.total_bounds).centroid
@@ -211,25 +212,46 @@ def iceberg_map(iceberg_sites: gpd.GeoDataFrame) -> folium.Map:
         location=[map_center.y, map_center.x], zoom_start=11, tiles="CartoDB positron"
     )
 
-    tooltip = folium.GeoJsonTooltip(
-        fields=["observed_date", "IcebergID"],
-        aliases=["Date", "Iceberg ID"],
+    tooltip_opts = dict(
         localize=True,
         sticky=False,
         labels=True,
         style="""
-            background-color: #F0EFEF;
-            border: 2px solid black;
-            border-radius: 3px;
-            box-shadow: 3px;
-        """,
+        background-color: #F0EFEF;
+        border: 2px solid black;
+        border-radius: 3px;
+        box-shadow: 3px;
+    """,
     )
 
+    # Shapes
+    render_columns = ["IcebergID", "observed_date", "geom", "date_rank"]
     shape_colors = unique_colors(iceberg_sites)
+
     folium.GeoJson(
-        iceberg_sites,
+        iceberg_sites[render_columns],
         style_function=lambda x: shape_color(x, shape_colors),
-        tooltip=tooltip,
+        tooltip=folium.GeoJsonTooltip(
+            fields=["observed_date", "IcebergID"],
+            aliases=["Date", "Iceberg ID"],
+            **tooltip_opts,
+        ),
+    ).add_to(map_element)
+
+    # Lines
+    folium.GeoJson(
+        site_lines,
+        style_function=lambda x: {
+            "stroke": True,
+            "color": shape_colors.get(x["properties"]["IcebergID"], "#808080"),
+            "weight": 2,
+            "opacity": 1.0,
+        },
+        tooltip=folium.GeoJsonTooltip(
+            fields=["distance_meters"],
+            aliases=["Distance (m):"],
+            **tooltip_opts,
+        ),
     ).add_to(map_element)
 
     return map_element

--- a/modules/shape_viewer.py
+++ b/modules/shape_viewer.py
@@ -4,6 +4,7 @@ import pandas as pd
 import streamlit as st
 from ibis import _
 from ibis import selectors as s
+from shapely.geometry import LineString
 
 from database import LOCATIONS_TABLE, MELT_RATES_TABLE, SHAPE_TABLE
 from modules import DATE_FORMAT
@@ -77,7 +78,12 @@ def map_data(site_select: dict, date_select: dict = None) -> gpd.GeoDataFrame:
             db_table(SHAPE_TABLE).Date.isin([date_select["start"], date_select["end"]])
         )
 
+    # Find matching early and late observations
     window = ibis.window(group_by=[_.IcebergID, _.filename], order_by=_.Date)
+    # For calculating distances
+    early_centroid = _.geom.centroid()
+    late_centroid = early_centroid.lead(1).over(window)
+
     shape_query = (
         db_table(SHAPE_TABLE)
         .filter(user_selection)
@@ -85,7 +91,32 @@ def map_data(site_select: dict, date_select: dict = None) -> gpd.GeoDataFrame:
             ~s.cols("Date", "filename"),
             date_rank=ibis.row_number().over(window),
             observed_date=db_table(SHAPE_TABLE).Date.strftime(DATE_FORMAT),
+            early_centroid_geom=early_centroid,
+            late_centroid_geom=late_centroid,
+            distance_meters=early_centroid.distance(late_centroid).round(0),
         )
     )
 
     return shape_query.to_pandas().set_crs("EPSG:3413")
+
+def shape_distances(data: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """
+    Calculate the distance between the early and late centroids for each shape.
+
+    :param data: GeoDataFrame with shape data
+
+    :return:
+        GeoDataFrame with distance between early and late centroids
+    """
+    site_lines = data[data["date_rank"] == 0]
+    line_geometries = [
+        LineString([(early.x, early.y), (late.x, late.y)])
+        for early, late in zip(
+            site_lines["early_centroid_geom"], site_lines["late_centroid_geom"]
+        )
+    ]
+    return gpd.GeoDataFrame(
+        site_lines[["IcebergID", "distance_meters"]],
+        geometry=line_geometries,
+        crs="EPSG:3413",
+    ).to_crs(epsg=4326)


### PR DESCRIPTION
Add a line that shows the distance between the early and late observation. This also makes it easier to identify matching pairs on the map.

Closes #14