### PR TITLE
App - Correct iceberg identity, add melt rate comparison, restyle UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Manuscript drafts, figures, and figure-generation scripts. Paper material
+# rather than application code, and the .docx/.pdf versions do not diff.
+draft/

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ two parts to complete this process:
 ### Downloading the required data
 
 The required data that powers this application is not included in this repository.
-To download the data, go to: TBD
+To download the data, go to:
+[ice-age_app_catalog-data.zip](https://drive.google.com/file/d/1d-Am__IgiIqlATwYyJXlJpQKYhfr2nFn/view)
 
 ### Starting the application
 

--- a/ice_age_app.py
+++ b/ice_age_app.py
@@ -1,6 +1,7 @@
 import streamlit as st
 
 from modules.database import db_exists
+from modules.styling import inject_global_styles
 
 # Application entry point
 #
@@ -8,34 +9,37 @@ from modules.database import db_exists
 #   * Home - Start page
 #   * Iceberg Viewer - Interactive map to see spatial orientation of icebergs
 #   * Statistics Dashboard - Loads and displays iceberg melt information and associated statistics.
+#   * Melt Rates - Compares iceberg melt rates across all glacier systems.
 #   * Research Methods - Displays the methods used for data generation and work flow
 #   * Field Work Experiences - Fun pictures from the field!
 #   * Acknowledgements - Displays authors and award numbers.
 
 if db_exists():
     data_pages = [
-        st.Page("pages/Iceberg-Viewer.py"),
-        st.Page("pages/Statistics-dashboard.py"),
+        st.Page("pages/Iceberg-Viewer.py", title="Iceberg Viewer"),
+        st.Page("pages/Statistics-dashboard.py", title="Statistics Dashboard"),
+        st.Page("pages/Melt-Rates.py", title="Melt Rates"),
     ]
 else:
     data_pages = []
 
 data_pages += [
-    st.Page("pages/Data-Import.py"),
+    st.Page("pages/Data-Import.py", title="Data Import"),
 ]
 
-st.set_page_config(layout="wide")
+st.set_page_config(layout="wide", page_title="ICE-AGE")
+inject_global_styles()
 pg = st.navigation(
     {
         "": [
-            st.Page("pages/Home.py", default=True)
+            st.Page("pages/Home.py", title="Home", default=True)
         ],
         "Data": data_pages,
         "About" : [
-            st.Page("pages/Research-methods.py"),
-            st.Page("pages/Field-Work-images.py"),
-            st.Page("pages/Image-Gallery.py"),
-            st.Page("pages/Acknowledgements.py"),
+            st.Page("pages/Research-methods.py", title="Research Methods"),
+            st.Page("pages/Field-Work-images.py", title="Field Work"),
+            st.Page("pages/Image-Gallery.py", title="Image Gallery"),
+            st.Page("pages/Acknowledgements.py", title="Acknowledgements"),
         ]
     }
 )

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,1 +1,5 @@
-DATE_FORMAT = "%Y-%m-%d"
+DATE_FORMAT = "%m/%d/%Y"
+# Stable machine-readable format for URL query params / matching, kept
+# separate from DATE_FORMAT (the human-facing display format) so changing
+# how dates are *shown* never breaks deep-linking / dropdown pre-selection.
+URL_DATE_FORMAT = "%Y-%m-%d"

--- a/modules/database.py
+++ b/modules/database.py
@@ -32,6 +32,13 @@ def clear_db_cache() -> None:
     Clear all cached database connection info and tables.
     This is used when creating or reimporting the database.
     """
+    # Imported lazily to avoid a circular import (both modules import this one).
+    from modules.melt_rates import melt_rate_observations, observation_month_range
+    from modules.shape_viewer import map_data
+
     db_exists.clear()
     db_table.clear()
     get_connection.clear()
+    map_data.clear()
+    melt_rate_observations.clear()
+    observation_month_range.clear()

--- a/modules/map_backgrounds.py
+++ b/modules/map_backgrounds.py
@@ -1,13 +1,13 @@
 import streamlit as st
 
 MAP_BACKGROUNDS = {
-    "Stadia": {
-        "tiles": "https://tiles.stadiamaps.com/tiles/alidade_satellite/{z}/{x}/{y}{r}.jpg",
-        "attribution": '&copy; CNES, Distribution Airbus DS, © Airbus DS, © PlanetObserver (Contains Copernicus Data) | &copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-    },
     "ESRI": {
         "tiles": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
         "attribution": 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
+    },
+    "Stadia": {
+        "tiles": "https://tiles.stadiamaps.com/tiles/alidade_satellite/{z}/{x}/{y}{r}.jpg",
+        "attribution": '&copy; CNES, Distribution Airbus DS, © Airbus DS, © PlanetObserver (Contains Copernicus Data) | &copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     },
 }
 

--- a/modules/melt_rates.py
+++ b/modules/melt_rates.py
@@ -1,0 +1,165 @@
+import ibis
+import pandas as pd
+import streamlit as st
+from ibis import _
+
+from database import LOCATIONS_TABLE, MELT_RATES_TABLE
+from modules.database import db_table
+
+# Column labels shared by the charts, the raw-data table and the CSV export, so
+# the units a reader sees on an axis are the same strings they get in the
+# download.
+MELT_RATE_LABEL = "Melt rate (m d⁻¹)"
+DRAFT_LABEL = "Draft, mean (m)"
+SURFACE_AREA_LABEL = "Surface area, mean (m²)"
+
+# Numeric columns arrive from DuckDB as DECIMAL, which pandas surfaces as
+# `object` dtype holding Decimal instances. Altair/Vega cannot encode those, so
+# every measure is cast to float in the query rather than being patched up
+# per-chart afterwards.
+_MEASURES = {
+    "melt_rate": "Melt_Rate",
+    "melt_rate_uncertainty": "Melt_Rate_uncertainty",
+    "draft": "Draft_mean",
+    "surface_area": "Surface_Area_mean",
+    "submerged_area": "Submerged_Area_mean",
+    "volume_change": "dVdt_mean",
+}
+
+RAW_DATA_COLUMNS = {
+    "site_id": "Site ID",
+    "site": "Glacier System",
+    "start": "Observation Start",
+    "end": "Observation End",
+    "melt_rate": MELT_RATE_LABEL,
+    "melt_rate_uncertainty": "Melt rate uncertainty (m d⁻¹)",
+    "draft": DRAFT_LABEL,
+    "surface_area": SURFACE_AREA_LABEL,
+    "submerged_area": "Submerged area, mean (m²)",
+    "volume_change": "Volume change (m³ d⁻¹)",
+}
+
+
+@st.cache_data
+def melt_rate_observations(site_ids: tuple[str, ...] | None = None) -> pd.DataFrame:
+    """
+    Load individual iceberg melt-rate observations across every glacier system.
+
+    Unlike :py:func:`modules.statistics.load_statistics`, which serves the
+    single-site dashboard, this returns one row per observed iceberg for *all*
+    (or a chosen subset of) systems so they can be compared against each other
+    on shared axes.
+
+    :param site_ids: Optional tuple of Glacier IDs to restrict the result to.
+                     A tuple (not a list) so the result stays cacheable.
+
+    :return:
+        DataFrame with one row per iceberg observation window, carrying both
+        the Glacier ID and the official system name.
+    """
+    melt = db_table(MELT_RATES_TABLE)
+    locations = db_table(LOCATIONS_TABLE)
+
+    query = melt.join(locations, melt.SiteID == locations.Glacier_ID).select(
+        site_id=melt.SiteID,
+        site=locations.Official_name,
+        start=melt.Date_start,
+        end=melt.Date_end,
+        **{
+            alias: melt[column].cast("float")
+            for alias, column in _MEASURES.items()
+        },
+    )
+
+    if site_ids:
+        query = query.filter(_.site_id.isin(list(site_ids)))
+
+    observations = query.order_by([ibis.asc(_.site_id), ibis.asc(_.start)]).execute()
+    # Month of the observation window's start, for seasonality encoding. Kept
+    # out of the SQL projection because it is a display concern rather than a
+    # stored measure, and it never reaches the CSV export (see raw_data_table).
+    observations["month"] = observations["start"].dt.month
+    return observations
+
+
+@st.cache_data
+def observation_month_range() -> tuple[int, int]:
+    """
+    Earliest and latest calendar month covered by the whole catalog.
+
+    Deliberately computed across every site rather than from a filtered frame:
+    it anchors the seasonal color scale, and a domain that moved with the site
+    filter would repaint the surviving points on every selection change.
+
+    :return:
+        ``(first_month, last_month)`` as 1-12 integers.
+    """
+    months = (
+        db_table(MELT_RATES_TABLE)
+        .aggregate(
+            first=_.Date_start.month().min(),
+            last=_.Date_start.month().max(),
+        )
+        .execute()
+    )
+    return int(months["first"].iloc[0]), int(months["last"].iloc[0])
+
+
+def site_summary(observations: pd.DataFrame) -> pd.DataFrame:
+    """
+    Rank glacier systems by their median melt rate.
+
+    Aggregated in pandas rather than in a second database query: the caller
+    already holds every observation it needs (the full catalog is on the order
+    of a thousand rows), so re-querying would cost a round trip to compute
+    something the in-memory frame already answers.
+
+    The median — not the mean — sets the ranking because per-site sample sizes
+    are small and uneven (single digits at some systems), where one unusually
+    fast-melting iceberg would otherwise decide a system's position.
+
+    :param observations: Frame from :py:func:`melt_rate_observations`.
+
+    :return:
+        One row per system with observation count, median and mean melt rate,
+        and a ``label`` combining the Glacier ID with its sample size.
+    """
+    if observations.empty:
+        return pd.DataFrame(
+            columns=["site_id", "site", "observations", "median", "mean", "label"]
+        )
+
+    summary = (
+        observations.groupby(["site_id", "site"], as_index=False)
+        .agg(
+            observations=("melt_rate", "size"),
+            median=("melt_rate", "median"),
+            mean=("melt_rate", "mean"),
+        )
+        .sort_values("median", ascending=False, ignore_index=True)
+    )
+    # The sample size rides along in the axis label so a reader can weigh a
+    # system's spread against how many icebergs produced it, without needing a
+    # second annotation layer on the chart.
+    summary["label"] = summary["site_id"] + "  (n=" + summary["observations"].astype(str) + ")"
+    return summary
+
+
+def raw_data_table(observations: pd.DataFrame) -> pd.DataFrame:
+    """
+    Rename the query's internal column names to their labelled, unit-carrying
+    equivalents for display and CSV export.
+
+    :param observations: Frame from :py:func:`melt_rate_observations`.
+
+    :return:
+        DataFrame with human-readable column headers.
+    """
+    # Selecting the mapped columns explicitly keeps display-only fields (e.g.
+    # the derived month) out of the table and the downloaded CSV.
+    table = observations[list(RAW_DATA_COLUMNS)].copy()
+    # Observation bounds are whole days: dropping the all-zero time component
+    # keeps the table readable and the exported CSV free of "00:00:00" noise.
+    for column in ("start", "end"):
+        table[column] = table[column].dt.date
+    return table.rename(columns=RAW_DATA_COLUMNS)

--- a/modules/plotting.py
+++ b/modules/plotting.py
@@ -6,7 +6,7 @@ from shapely.geometry import box
 from streamlit_folium import st_folium
 
 from modules.map_backgrounds import MAP_BACKGROUNDS
-from modules.shape_viewer import locations_with_shape, shape_distances
+from modules.shape_viewer import locations_with_shape, shape_arrowheads, shape_distances
 
 
 def map_overlay_css():
@@ -84,11 +84,15 @@ def overview_map(map_style: str) -> dict:
         locations_with_shape(), geometry="geometry", crs="EPSG:4326"
     )
 
+    minx, miny, maxx, maxy = glacier_sites.total_bounds.tolist()
+    # Center explicitly on the study-site bounding box (roughly Greenland's
+    # extent) rather than relying only on fit_bounds, whose centering can
+    # shift with the container's aspect ratio.
     map = folium.Map(
+        location=[(miny + maxy) / 2, (minx + maxx) / 2],
         tiles=map_style["tiles"],
         attr=map_style["attribution"],
     )
-    minx, miny, maxx, maxy = glacier_sites.total_bounds.tolist()
     map.fit_bounds([[miny, minx], [maxy, maxx]])
 
     # Color each marker based on data availability in the database
@@ -130,6 +134,7 @@ def overview_map(map_style: str) -> dict:
     return st_folium(
         map,
         use_container_width=True,
+        height=480,
         returned_objects=["last_active_drawing"],
     )
 
@@ -160,22 +165,30 @@ def shape_color(map_element: dict, color_map: dict) -> dict:
     :return:
         Dictionary with style settings for the map element
     """
-    iceberg_id = map_element["properties"]["IcebergID"]
+    # IcebergID is only unique within one campaign (filename): the same ID
+    # is reused across unrelated campaigns/years, so both are needed to
+    # identify a specific iceberg and give it a consistent, distinct color.
+    campaign_key = (
+        map_element["properties"]["IcebergID"],
+        map_element["properties"]["filename"],
+    )
 
     # Show the date combinations with different styles.
     # The early date has 0 as date_rank
     if map_element["properties"]["date_rank"] == 0:
         line_color = "black"
         opacity = 0.7
-        weight = 1
-    else:
-        line_color = "darkgray"
-        opacity = 0.6
         weight = 2
+    else:
+        # The ending (most recent) observation of each iceberg is bolded so
+        # it stands out from its earlier observation(s).
+        line_color = "black"
+        opacity = 0.9
+        weight = 4
 
     return {
         "color": line_color,
-        "fillColor": color_map.get(iceberg_id, "#808080"),
+        "fillColor": color_map.get(campaign_key, "#808080"),
         "weight": weight,
         "fillOpacity": opacity,
     }
@@ -183,16 +196,20 @@ def shape_color(map_element: dict, color_map: dict) -> dict:
 
 def unique_colors(iceberg_sites: gpd.GeoDataFrame) -> dict:
     """
-    Create a unique color for each iceberg.
+    Create a unique color for each iceberg, keyed by (IcebergID, filename)
+    since IcebergID alone is only unique within a single campaign's
+    shapefile and is reused across unrelated campaigns/years.
 
     :param iceberg_sites: GeoDataFrame with icebergs
 
     :return:
-        Dictionary with unique colors for each iceberg
+        Dictionary with unique colors for each (IcebergID, filename) iceberg
     """
-    iceberg_ids = iceberg_sites["IcebergID"].unique()
-    palette = cc.glasbey[: len(iceberg_ids)]
-    return {ice_id: palette[index] for index, ice_id in enumerate(iceberg_ids)}
+    campaign_keys = (
+        iceberg_sites[["IcebergID", "filename"]].drop_duplicates().apply(tuple, axis=1)
+    )
+    palette = cc.glasbey[: len(campaign_keys)]
+    return {key: palette[index] for index, key in enumerate(campaign_keys)}
 
 
 def iceberg_map(iceberg_sites: gpd.GeoDataFrame) -> folium.Map:
@@ -205,12 +222,26 @@ def iceberg_map(iceberg_sites: gpd.GeoDataFrame) -> folium.Map:
         Folium map object
     """
     site_lines = shape_distances(iceberg_sites)
+    arrows = shape_arrowheads(iceberg_sites)
     iceberg_sites.to_crs("EPSG:4326", inplace=True)
 
     map_center = box(*iceberg_sites.total_bounds).centroid
-    map_element = folium.Map(
-        location=[map_center.y, map_center.x], zoom_start=11, tiles="CartoDB positron"
-    )
+    esri = MAP_BACKGROUNDS["ESRI"]
+    map_element = folium.Map(location=[map_center.y, map_center.x], tiles=None)
+    # Muted opacity on the satellite basemap so the iceberg overlays (added
+    # at full opacity below) read as the clear focal layer, not the imagery.
+    folium.TileLayer(
+        tiles=esri["tiles"], attr=esri["attribution"], opacity=0.6,
+    ).add_to(map_element)
+    # Dedicated pane above the default overlay pane so arrowheads always
+    # render on top of the iceberg polygons, regardless of layer add order.
+    folium.map.CustomPane("arrowheads", z_index=650).add_to(map_element)
+    # Fit to the actual extent of the icebergs being shown, rather than a
+    # fixed zoom level, so the view always bounds the available data
+    # (a fixed zoom either clips widely-scattered icebergs or leaves a
+    # tightly-clustered set zoomed out too far).
+    minx, miny, maxx, maxy = iceberg_sites.total_bounds
+    map_element.fit_bounds([[miny, minx], [maxy, maxx]])
 
     tooltip_opts = dict(
         localize=True,
@@ -225,33 +256,102 @@ def iceberg_map(iceberg_sites: gpd.GeoDataFrame) -> folium.Map:
     )
 
     # Shapes
-    render_columns = ["IcebergID", "observed_date", "geom", "date_rank"]
+    iceberg_sites["velocity_display"] = iceberg_sites["velocity_m_per_day"].apply(
+        lambda v: f"{v:.1f} m d⁻¹" if v == v else "N/A (last observation in this campaign)"
+    )
+    render_columns = [
+        "IcebergID", "filename", "observed_date", "geom", "date_rank", "velocity_display",
+    ]
     shape_colors = unique_colors(iceberg_sites)
 
-    folium.GeoJson(
+    shapes_layer = folium.GeoJson(
         iceberg_sites[render_columns],
         style_function=lambda x: shape_color(x, shape_colors),
         tooltip=folium.GeoJsonTooltip(
-            fields=["observed_date", "IcebergID"],
-            aliases=["Date", "Iceberg ID"],
+            fields=["observed_date", "IcebergID", "velocity_display"],
+            aliases=["Date", "Iceberg ID", "Drift velocity to next observation"],
             **tooltip_opts,
         ),
     ).add_to(map_element)
 
-    # Lines
+    # Lines: a wider black "casing" line drawn first, then the colored line
+    # on top and slightly thinner, so every line reads as color-with-a-
+    # black-outline against the busy satellite background.
     folium.GeoJson(
         site_lines,
-        style_function=lambda x: {
-            "stroke": True,
-            "color": shape_colors.get(x["properties"]["IcebergID"], "#808080"),
-            "weight": 2,
-            "opacity": 1.0,
-        },
+        style_function=lambda x: {"stroke": True, "color": "black", "weight": 4, "opacity": 1.0},
+    ).add_to(map_element)
+    line_color_style = lambda x: {
+        "stroke": True,
+        "color": shape_colors.get(
+            (x["properties"]["IcebergID"], x["properties"]["filename"]), "#808080"
+        ),
+        "weight": 2.5,
+        "opacity": 1.0,
+    }
+    lines_layer = folium.GeoJson(
+        site_lines,
+        style_function=line_color_style,
         tooltip=folium.GeoJsonTooltip(
             fields=["distance_meters"],
             aliases=["Distance (m):"],
             **tooltip_opts,
         ),
     ).add_to(map_element)
+
+    # Arrowheads at the end (late observation) of each line, so the
+    # direction of travel is visible without relying on the tooltip.
+    folium.GeoJson(
+        arrows,
+        style_function=lambda x: {
+            "stroke": True,
+            "color": "black",
+            "weight": 2,
+            "fillColor": shape_colors.get(
+                (x["properties"]["IcebergID"], x["properties"]["filename"]), "#808080"
+            ),
+            "fillOpacity": 1.0,
+            "pane": "arrowheads",
+        },
+    ).add_to(map_element)
+
+    # Hovering an iceberg highlights its connecting line: the shapes and
+    # lines are separate Leaflet layers, so this needs a small script to
+    # match features between them (by IcebergID + campaign filename, since
+    # IcebergID alone is reused across unrelated campaigns) and restyle the
+    # matching line on mouseover/mouseout.
+    highlight_js = f"""
+    (function() {{
+        var shapesLayer = {shapes_layer.get_name()};
+        var linesLayer = {lines_layer.get_name()};
+        function key(props) {{ return props.IcebergID + "||" + props.filename; }}
+        // Reset every line first, then (re-)apply the highlight for the
+        // hovered shape. This is deliberately not "just" reset-on-mouseout:
+        // fast/synthetic pointer movement between adjacent map features can
+        // skip a clean mouseout on the previously-hovered shape, which would
+        // otherwise leave a stale highlight stuck on screen.
+        function resetLines() {{
+            linesLayer.eachLayer(function(lineFeature) {{ lineFeature.setStyle({{weight: 2.5}}); }});
+        }}
+        shapesLayer.eachLayer(function(shapeFeature) {{
+            var shapeKey = key(shapeFeature.feature.properties);
+            shapeFeature.on("mouseover", function() {{
+                resetLines();
+                linesLayer.eachLayer(function(lineFeature) {{
+                    if (key(lineFeature.feature.properties) === shapeKey) {{
+                        lineFeature.setStyle({{weight: 6}});
+                        lineFeature.bringToFront();
+                    }}
+                }});
+            }});
+            shapeFeature.on("mouseout", resetLines);
+        }});
+    }})();
+    """
+    # Added to the `script` root element (not `html`): layer creation code
+    # for shapes_layer/lines_layer also lives there, in the order added, so
+    # this must be appended after them to reference already-defined
+    # variables rather than risk running before the map/layers exist.
+    map_element.get_root().script.add_child(folium.Element(highlight_js))
 
     return map_element

--- a/modules/shape_viewer.py
+++ b/modules/shape_viewer.py
@@ -1,13 +1,15 @@
+import math
+
 import geopandas as gpd
 import ibis
 import pandas as pd
 import streamlit as st
 from ibis import _
 from ibis import selectors as s
-from shapely.geometry import LineString
+from shapely.geometry import LineString, Polygon
 
 from database import LOCATIONS_TABLE, MELT_RATES_TABLE, SHAPE_TABLE
-from modules import DATE_FORMAT
+from modules import DATE_FORMAT, URL_DATE_FORMAT
 from modules.database import db_table
 
 
@@ -54,6 +56,10 @@ def shape_dates_for_site(site_id: str) -> pd.DataFrame:
         .mutate(
             start_date=_.start.strftime(DATE_FORMAT),
             end_date=_.end.strftime(DATE_FORMAT),
+            # Stable identifiers for URL round-tripping, independent of the
+            # display format above.
+            url_start=_.start.strftime(URL_DATE_FORMAT),
+            url_end=_.end.strftime(URL_DATE_FORMAT),
         )
         .order_by("start")
         .distinct()
@@ -72,29 +78,64 @@ def map_data(site_select: dict, date_select: dict = None) -> gpd.GeoDataFrame:
     :return:
         GeoDataFrame with all shapes for the given site and date range
     """
-    user_selection = [db_table(SHAPE_TABLE).SiteID == site_select["Glacier_ID"]]
+    table = db_table(SHAPE_TABLE)
+    user_selection = table.SiteID == site_select["Glacier_ID"]
     if date_select:
-        user_selection.append(
-            db_table(SHAPE_TABLE).Date.isin([date_select["start"], date_select["end"]])
+        # Scope to the specific campaign file(s) whose (min, max) date matches
+        # the selection, rather than matching Date by value site-wide: two
+        # adjacent campaigns can share a boundary date (e.g. one ends and the
+        # next begins on the same day), which would otherwise pull rows from
+        # the wrong campaign into the same (IcebergID, filename) group below.
+        campaign_dates = table.filter(user_selection).group_by(
+            table.IcebergID, table.filename
+        ).aggregate(start=table.Date.min(), end=table.Date.max())
+        matching_files = (
+            campaign_dates.filter(
+                (campaign_dates.start == date_select["start"])
+                & (campaign_dates.end == date_select["end"])
+            )
+            .select("filename")
+            .distinct()
         )
+        user_selection = user_selection & table.filename.isin(matching_files.filename)
+
+    filtered = table.filter(user_selection)
+
+    # De-duplicate to at most one row per (IcebergID, filename, Date): some
+    # source shapefiles contain duplicate digitizations for the same
+    # iceberg/date, which would otherwise make the early/late pairing below
+    # (and the resulting distance) unreliable.
+    dedup_window = ibis.window(group_by=[_.IcebergID, _.filename, _.Date])
+    deduped = (
+        filtered.mutate(_dup_rank=ibis.row_number().over(dedup_window))
+        .filter(_._dup_rank == 0)
+        .drop("_dup_rank")
+    )
 
     # Find matching early and late observations
     window = ibis.window(group_by=[_.IcebergID, _.filename], order_by=_.Date)
     # For calculating distances
     early_centroid = _.geom.centroid()
     late_centroid = early_centroid.lead(1).over(window)
+    late_date = deduped.Date.lead(1).over(window)
+    days_elapsed = late_date.delta(deduped.Date, unit="days")
+    distance_meters = early_centroid.distance(late_centroid).round(0)
 
-    shape_query = (
-        db_table(SHAPE_TABLE)
-        .filter(user_selection)
-        .select(
-            ~s.cols("Date", "filename"),
-            date_rank=ibis.row_number().over(window),
-            observed_date=db_table(SHAPE_TABLE).Date.strftime(DATE_FORMAT),
-            early_centroid_geom=early_centroid,
-            late_centroid_geom=late_centroid,
-            distance_meters=early_centroid.distance(late_centroid).round(0),
-        )
+    shape_query = deduped.select(
+        # Keep filename (campaign): IcebergID is only a label local to one
+        # campaign's shapefile and is reused across unrelated campaigns, so
+        # (IcebergID, filename) together are needed downstream to tell two
+        # actually-different icebergs apart (e.g. for map coloring).
+        ~s.cols("Date"),
+        date_rank=ibis.row_number().over(window),
+        observed_date=deduped.Date.strftime(DATE_FORMAT),
+        early_centroid_geom=early_centroid,
+        late_centroid_geom=late_centroid,
+        distance_meters=distance_meters,
+        # Straight-line drift speed between this observation and the next
+        # one for the same iceberg; null where there is no next observation
+        # (the "late" row of a pair, or a singleton observation).
+        velocity_m_per_day=(distance_meters / days_elapsed).round(1),
     )
 
     return shape_query.to_pandas().set_crs("EPSG:3413")
@@ -108,7 +149,7 @@ def shape_distances(data: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     :return:
         GeoDataFrame with distance between early and late centroids
     """
-    site_lines = data[data["date_rank"] == 0]
+    site_lines = data[(data["date_rank"] == 0) & data["late_centroid_geom"].notna()]
     line_geometries = [
         LineString([(early.x, early.y), (late.x, late.y)])
         for early, late in zip(
@@ -116,7 +157,57 @@ def shape_distances(data: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
         )
     ]
     return gpd.GeoDataFrame(
-        site_lines[["IcebergID", "distance_meters"]],
+        site_lines[["IcebergID", "filename", "distance_meters", "velocity_m_per_day"]],
         geometry=line_geometries,
+        crs="EPSG:3413",
+    ).to_crs(epsg=4326)
+
+
+def _arrowhead_polygon(start_x, start_y, end_x, end_y) -> Polygon:
+    """
+    Build a small triangle pointing from (start_x, start_y) toward
+    (end_x, end_y), tip at the end point. Sized relative to the line's own
+    length (capped) so it stays visible on both short and long displacements.
+
+    :return:
+        Triangle Polygon in the same (projected, meters) units as the input.
+    """
+    dx, dy = end_x - start_x, end_y - start_y
+    length = math.hypot(dx, dy)
+    if length == 0:
+        length = 1.0
+    ux, uy = dx / length, dy / length  # unit vector along the line
+    px, py = -uy, ux  # unit vector perpendicular to the line
+
+    arrow_len = min(max(length * 0.15, 35), 180)
+    arrow_width = arrow_len * 0.55
+
+    back_x, back_y = end_x - ux * arrow_len, end_y - uy * arrow_len
+    left = (back_x + px * arrow_width / 2, back_y + py * arrow_width / 2)
+    right = (back_x - px * arrow_width / 2, back_y - py * arrow_width / 2)
+    return Polygon([(end_x, end_y), left, right])
+
+
+def shape_arrowheads(data: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """
+    Build a small directional arrowhead at the end (late observation) of
+    each iceberg's displacement line, so its direction of travel is visible
+    at a glance rather than only inferable from a plain line.
+
+    :param data: GeoDataFrame with shape data (see :py:func:`map_data`)
+
+    :return:
+        GeoDataFrame of triangle Polygons, one per drawable displacement.
+    """
+    site_lines = data[(data["date_rank"] == 0) & data["late_centroid_geom"].notna()]
+    arrow_geometries = [
+        _arrowhead_polygon(early.x, early.y, late.x, late.y)
+        for early, late in zip(
+            site_lines["early_centroid_geom"], site_lines["late_centroid_geom"]
+        )
+    ]
+    return gpd.GeoDataFrame(
+        site_lines[["IcebergID", "filename"]],
+        geometry=arrow_geometries,
         crs="EPSG:3413",
     ).to_crs(epsg=4326)

--- a/modules/statistics.py
+++ b/modules/statistics.py
@@ -4,7 +4,7 @@ from ibis import _
 from ibis.expr.types import Table
 
 from database import MELT_RATES_TABLE
-from modules import DATE_FORMAT
+from modules import DATE_FORMAT, URL_DATE_FORMAT
 from modules.database import db_table
 
 
@@ -27,6 +27,8 @@ def statistic_dates_for_site(site_name: str) -> pd.DataFrame:
         .mutate(
             start_date=_.start.strftime(DATE_FORMAT),
             end_date=_.end.strftime(DATE_FORMAT),
+            url_start=_.start.strftime(URL_DATE_FORMAT),
+            url_end=_.end.strftime(URL_DATE_FORMAT),
         )
         .distinct()
         .order_by(ibis.asc(_.start))
@@ -82,10 +84,10 @@ def key_statistics(site_name: str, date: str = None) -> pd.DataFrame:
         .aggregate(
             [
                 table.date_difference.mean().cast("int").name("Number of Days"),
-                table.Surface_Area_mean.mean().round(2).name("Surface Area Mean (m^2)"),
+                table.Surface_Area_mean.mean().round(2).name("Surface Area Mean (m²)"),
                 table.Draft_mean.mean().round(2).name("Draft Mean (m)"),
-                table.dVdt_mean.mean().round(2).name("Volume change (m^3/day)"),
-                table.Melt_Rate.mean().name("Melt Rate (m/day)"),
+                table.dVdt_mean.mean().round(2).name("Volume Change (m³ d⁻¹)"),
+                table.Melt_Rate.mean().name("Melt Rate (m d⁻¹)"),
                 table.Melt_Rate_uncertainty.mean().name("Melt Rate Uncertainty"),
             ]
         )
@@ -95,37 +97,6 @@ def key_statistics(site_name: str, date: str = None) -> pd.DataFrame:
                     DATE_FORMAT
                 ),
             }
-        )
-    ).execute()
-
-
-def key_statistics_chart_data(site_name: str, date: str = None) -> pd.DataFrame:
-    """
-    Get key statistics data for the charts in the metrics display.
-    See ::py:func:`key_statistics` for loaded columns.
-
-    :param site_name: Site name to filter by
-    :param date: Optionally further filter by date
-
-    :return:
-        Dataframe with results.
-    """
-    return (
-        filter_site(site_name, date).select(
-            [
-                db_table(MELT_RATES_TABLE).Date_start.name("Observation Start"),
-                db_table(MELT_RATES_TABLE).Surface_Area_mean.round(2).name(
-                    "Surface Area Mean (m^2)"
-                ),
-                db_table(MELT_RATES_TABLE).Draft_mean.round(2).name("Draft Mean (m)"),
-                db_table(MELT_RATES_TABLE).dVdt_mean.round(2).name(
-                    "Volume change (m^3/day)"
-                ),
-                db_table(MELT_RATES_TABLE).Melt_Rate.name("Melt Rate (m/day)"),
-                db_table(MELT_RATES_TABLE).Melt_Rate_uncertainty.name(
-                    "Melt Rate Uncertainty"
-                ),
-            ]
         )
     ).execute()
 

--- a/modules/styling.py
+++ b/modules/styling.py
@@ -1,0 +1,126 @@
+import streamlit as st
+
+GLOBAL_CSS = """
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap');
+
+/* Cards used for callout content (Home, Acknowledgements, metric tiles) */
+.card, .content-box {
+    background-color: #EAF3FA;
+    border: 1px solid #CBDCE8;
+    border-left: 4px solid #0E7C9E;
+    border-radius: 10px;
+    padding: 1.25rem 1.5rem;
+    margin: 0.5rem 0 1rem 0;
+}
+.card ul, .content-box ul {
+    margin-bottom: 0;
+}
+
+/* Icon + label metric tiles, e.g. Home's "Available Iceberg Metrics" */
+.metric-tile {
+    background-color: #EAF3FA;
+    border: 1px solid #CBDCE8;
+    border-top: 4px solid #0047AB;
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+    min-height: 130px;
+    display: flex;
+    flex-direction: column;
+}
+.metric-tile .metric-tile-icon {
+    font-size: 1.6rem;
+    line-height: 1;
+}
+.metric-tile .metric-tile-label {
+    font-weight: 600;
+    margin-top: 0.4rem;
+    display: block;
+}
+
+/* Soft rounded frame + shadow for embedded maps (folium). Deliberately NOT
+applied to .stImage img: several figures on Research-Methods already have
+their own baked-in rectangular border, and rounding the CSS bounding box
+on top of that clips across the image's own border, showing as a stray
+dark/blue outline at the corners. */
+[data-testid="stIFrame"] {
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 2px 10px rgba(20, 60, 90, 0.12);
+}
+</style>
+"""
+
+
+def resample_colors(anchors: list[str], count: int) -> list[str]:
+    """
+    Resample a list of anchor hex colors into exactly ``count`` evenly spaced
+    hex colors, interpolating linearly in RGB between neighbouring anchors.
+
+    Lets a chart hand a colormap's stops to a discrete (ordinal) color scale
+    whose category count is driven by the data, without pulling a plotting
+    library in at runtime just to sample a ramp.
+
+    :param anchors: Ordered ``#rrggbb`` stops describing the colormap.
+    :param count: Number of colors to return.
+
+    :return:
+        List of ``count`` ``#rrggbb`` strings, starting and ending on the
+        first and last anchor.
+    """
+    if count <= 0:
+        return []
+    if count == 1:
+        return [anchors[0]]
+
+    channels = [
+        tuple(int(anchor[index : index + 2], 16) for index in (1, 3, 5))
+        for anchor in anchors
+    ]
+
+    colors = []
+    for step in range(count):
+        # Position along the anchor list, as a float index into `channels`.
+        position = step * (len(channels) - 1) / (count - 1)
+        low = int(position)
+        high = min(low + 1, len(channels) - 1)
+        weight = position - low
+        blended = (
+            round(channels[low][channel] * (1 - weight) + channels[high][channel] * weight)
+            for channel in range(3)
+        )
+        colors.append("#{:02x}{:02x}{:02x}".format(*blended))
+    return colors
+
+
+def inject_global_styles() -> None:
+    """
+    Inject shared CSS (fonts, .card/.content-box, .metric-tile, and rounded
+    image/map framing) once for the whole app.
+    """
+    st.markdown(GLOBAL_CSS, unsafe_allow_html=True)
+
+
+def centered_image(path: str, caption: str = None, width: int = 650) -> None:
+    """
+    Render an image centered on the page at a fixed, readable width instead
+    of stretching it to the full (often very wide) main-content container.
+    """
+    _, center, _ = st.columns([1, 3, 1])
+    with center:
+        st.image(path, caption=caption, width=width)
+
+
+def metric_tile(icon: str, label: str) -> None:
+    """
+    Render a small icon + label tile (used for Home's feature/metric list).
+    """
+    st.markdown(
+        f"""
+        <div class="metric-tile">
+            <span class="metric-tile-icon">{icon}</span>
+            <span class="metric-tile-label">{label}</span>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )

--- a/modules/ui_elements.py
+++ b/modules/ui_elements.py
@@ -7,7 +7,7 @@ from ibis.expr.types import Table
 from database import LOCATIONS_TABLE
 from modules.database import db_table
 
-GLACIER_ID_KEY = db_table(LOCATIONS_TABLE).Glacier_ID.get_name()
+GLACIER_ID_KEY = "Glacier_ID"
 
 SITE_SELECTOR_KEY = "site_name_selector"
 SITE_PARAM = "site_id"
@@ -39,7 +39,9 @@ def site_name_selector(join_table: Table, selected_site=None):
         index = (options[GLACIER_ID_KEY] == selected_site).idxmax()
         index = int(index)  # Streamlit needs an int and not int64
     else:
-        index = None
+        # Default to the first available site so the page shows data
+        # immediately instead of an empty "select a site" state.
+        index = 0 if len(options) else None
 
     return st.selectbox(
         "Site Name:",
@@ -75,18 +77,27 @@ def date_range_selector(date_ranges: pd.DataFrame, selected_date_range=None):
         Streamlit select UI object
     """
     if selected_date_range:
-        start_date, _end_date = selected_date_range.split("_")
-        index = date_ranges[date_ranges.start == start_date]["start"].idxmax()
-        index = int(index)  # Streamlit needs an int and not int64
+        # Match against the stable url_start column (not the raw `start`
+        # date, and not the display-formatted start_date, both of which are
+        # sensitive to DATE_FORMAT/type coercion) so pre-selection from a
+        # URL/deep-link is independent of the display date format.
+        url_start, _url_end = selected_date_range.split("_")
+        matches = date_ranges[date_ranges.url_start == url_start]
+        index = int(matches["start"].idxmax()) if len(matches) else None
     else:
         index = None
 
+    if index is None:
+        # Default to the first available observation period so the page
+        # shows data immediately instead of an empty "select a period" state.
+        index = 0 if len(date_ranges) else None
+
     return st.selectbox(
-        "Observation Periods (start - end):",
+        "Observation Periods (start – end):",
         date_ranges.to_dict("records"),
         index=index,
         placeholder="Filter to an observation period",
-        format_func=lambda x: f"{x['start_date']} to {x['end_date']}",
+        format_func=lambda x: f"{x['start_date']} – {x['end_date']}",
         key=DATE_RANGE_KEY,
         on_change=update_date_range_url_param,
     )
@@ -101,7 +112,7 @@ def update_date_range_url_param():
         selection = st.session_state[DATE_RANGE_KEY]
         if selection:
             st.query_params[DATE_PARAM] = (
-                f"{selection['start_date']}_{selection['end_date']}"
+                f"{selection['url_start']}_{selection['url_end']}"
             )
     else:
         st.query_params.pop(DATE_PARAM, None)

--- a/pages/Acknowledgements.py
+++ b/pages/Acknowledgements.py
@@ -26,7 +26,7 @@ st.html(
 )
 
 # Titles and content
-st.title("🥳 Acknowledgements:")
+st.title("Acknowledgements")
 st.info(
     "Project funding via NSF Arctic Natural Sciences awards #2052561, #2052549, #205255"
 )
@@ -43,7 +43,7 @@ st.html(
     """
 )
 
-st.title("🔮 The Future of ICE-AGE:")
+st.title("The Future of ICE-AGE")
 st.html(
     """
     <div class="card">
@@ -60,25 +60,25 @@ st.markdown(
     "[ICEBERGER: Interactive Tool for Iceberg Research](https://joshdata.me/iceberger.html)"
 )
 st.markdown(
-    "[Zenodo Record - ICE-AGE Data](https://zenodo.org/records/8007035)"
+    "[Iceberg Melange Fragmentation Theory (code, Enderlin et al.)]"
+    "(https://zenodo.org/records/8007035)"
+)
+
+st.header("References", divider=True)
+st.markdown(
+    "- Enderlin, E. M., Liu, J., and Kopera, M. (2023). "
+    "ellynenderlin/melange-fragmentation-theory: v0.1.2. Zenodo. "
+    "[https://doi.org/10.5281/zenodo.8007035](https://doi.org/10.5281/zenodo.8007035)"
 )
 
 # Sidebar with images aligned side by side
 col1, col2 = st.sidebar.columns(2)
 
 # Image for NSIDC on the left column
-col1.image(
-    "catalog-data/images/NSIDC.png",
-    use_container_width=True,
-    width=240
-)
+col1.image("catalog-data/images/NSIDC.png", width=200)
 
 # Image for NSF on the right column
-col2.image(
-    "catalog-data/images/NSF.png",
-    use_container_width=True,
-    width=250
-)
+col2.image("catalog-data/images/NSF.png", width=200)
 
 # Existing sidebar images
 st.sidebar.image(

--- a/pages/Data-Import.py
+++ b/pages/Data-Import.py
@@ -31,11 +31,11 @@ st.markdown(
 st.header("Steps", divider=True)
 st.markdown(
     """
-    ### 1. Download the data from [Zenodo](https://zenodo.org/)
-    
-    All data for this app is publicly available on Zenodo.
-    [LINK](https://)
-    
+    ### 1. Download the data
+
+    Download the catalog data archive:
+    [ice-age_app_catalog-data.zip](https://drive.google.com/file/d/1d-Am__IgiIqlATwYyJXlJpQKYhfr2nFn/view)
+
     ### 2. Create a folder inside the application repository
     
     On your local machine, go to the root location where you copied the repository from GitHub. 
@@ -81,7 +81,7 @@ if st.button("Populate DB", type="primary"):
 if db_exists():
     st.markdown(
         """   
-            ### 5. All Done!
+            ### 5. All done!
             
             You are now ready to explore the data. The side navigation bar now has additional
             entries under the __"Data"__ category. The homepage will now show the overview 

--- a/pages/Field-Work-images.py
+++ b/pages/Field-Work-images.py
@@ -1,13 +1,31 @@
 import streamlit as st
 
+from modules.styling import centered_image
+
+st.title("Field Work")
 st.markdown(
-    """
-    <style>
-    /* Title text color */
-    .stTitle {
-        color: #000000;
-    }
-    </style>
-    """,
-    unsafe_allow_html=True
+    "Photos from Greenland fieldwork and ship-based surveys that support "
+    "ICE-AGE's imagery and melt-rate observations."
 )
+
+IMAGES = [
+    "catalog-data/images/Calving.png",
+    "catalog-data/images/Boats-n-icebergs.png",
+]
+CAPTIONS = [
+    (
+        "An iceberg towers above the waters of Ilulissat Icefjord, after "
+        "calving off of Sermeq Kujalleq, or Jakobshavn Glacier, in western "
+        "Greenland. Credit: Allen Pope, NSIDC"
+    ),
+    (
+        "A scientific research vessel churns through the coastal waters of "
+        "western Greenland, leaving an open path through small icebergs and "
+        "bergy bits. Instruments deployed in the region help researchers "
+        "better understand ocean conditions and how narwhal whales use the "
+        "glacial fjord environment. Credit: Twila Moon, NSIDC"
+    ),
+]
+
+for image, caption in zip(IMAGES, CAPTIONS):
+    centered_image(image, caption=caption)

--- a/pages/Home.py
+++ b/pages/Home.py
@@ -1,8 +1,8 @@
 import streamlit as st
 
 from modules.database import db_exists
-from modules.map_backgrounds import map_style_selector
 from modules.plotting import last_viewed_site, map_overlay_css, overview_map
+from modules.styling import metric_tile
 from modules.ui_elements import GLACIER_ID_KEY, shapes_button, statistics_button
 
 st.markdown(
@@ -16,31 +16,25 @@ st.markdown(
 
 st.html(
     """
-    <h1 style="
-        font-family: 'Bungee Shade', 'Audiowide', sans-serif;
-        font-size: 40px;
-        text-align: center;
-        background: linear-gradient(90deg, #9c27b0, #e91e63, #ff5722, #ffeb3b);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;">
-        ICE-AGE Innovation: Empowering Iceberg Analysis in Greenland Environments
+    <h1 style="font-family: 'Poppins', sans-serif; font-weight: 700;
+               font-size: 2.5rem; margin: 0 0 0.5rem 0; line-height: 1.2;">
+        <span style="color: #0047AB;">ICE-AGE</span><span style="color: #0B2545;">:</span>
+        <span style="color: #0E7C9E;">Iceberg Catalog for Analysis of Greenland Environments</span>
     </h1>
-    """,
+    """
 )
-
-st.text(
-    "The ICE-AGE catalog is a powerful tool for iceberg research, offering "
-    "easy access to iceberg identification, metrics, and imagery."
+st.markdown(
+    "ICE-AGE is a research tool for exploring iceberg identification, "
+    "metrics, and imagery across Greenland's coastal waters."
 )
 
 if db_exists():
     st.header("Study Sites in Greenland", divider=True)
     map_overlay_css()
-    map_style = map_style_selector()
 
     with st.container(key="glacier-map-container"):
         with st.container(key="glacier-map"):
-            map_click = overview_map(map_style)
+            map_click = overview_map("ESRI")
 
         with st.container(key="glacier-options"):
             if map_click:
@@ -63,7 +57,7 @@ if db_exists():
                             '<i class="fa-solid fa-map-marker" style="color: #808080; margin-right: 8px;"></i>No data available'
                         )
 else:
-    st.header("Setup instructions", divider=True)
+    st.header("Setup Instructions", divider=True)
     st.text(
         "To use the ICE-AGE catalog, you will need to set up the database and import "
         "the underlying data from a published Zenodo data set. Please go to the "
@@ -73,14 +67,10 @@ else:
         st.switch_page("pages/Data-Import.py")
 
 st.header("Available Iceberg Metrics", divider=True)
-st.html(
-    """
-    <div class="content-box metrics-box">
-        <ul>
-            <li>Location, repeat imagery metadata, and identification for iceberg studies.</li>
-            <li>Access code for shapefiles to connect to ICE-AGE metrics.</li>
-            <li>Iceberg size, volume, draft, and submerged area data.</li>
-        </ul>
-    </div>
-    """,
-)
+metric_cols = st.columns(3)
+with metric_cols[0]:
+    metric_tile("📍", "Location, repeat imagery metadata, and identification for iceberg studies.")
+with metric_cols[1]:
+    metric_tile("🧊", "Access code for shapefiles to connect to ICE-AGE metrics.")
+with metric_cols[2]:
+    metric_tile("📏", "Iceberg size, volume, draft, and submerged area data.")

--- a/pages/Iceberg-Viewer.py
+++ b/pages/Iceberg-Viewer.py
@@ -41,8 +41,15 @@ if site_select:
 
 if site_select:
     st.header("Map")
+    st.caption(
+        "Lines connect an iceberg's repeat observations only within a single "
+        "imagery campaign. Iceberg ID numbers are reused across different "
+        "campaigns/years for unrelated icebergs, so observations from "
+        "different campaigns are never connected, even if shown in the same "
+        "color."
+    )
 
     glacier_sites = map_data(site_select, date_range)
     map_object = iceberg_map(glacier_sites)
 
-    st_folium(map_object, use_container_width=True, returned_objects=None)
+    st_folium(map_object, use_container_width=True, height=480, returned_objects=None)

--- a/pages/Image-Gallery.py
+++ b/pages/Image-Gallery.py
@@ -1,5 +1,7 @@
 import streamlit as st
 
+from modules.styling import centered_image
+
 IMAGES = [
     "catalog-data/images/Ice-bridge.png",
     "catalog-data/images/Icebergs.png",
@@ -38,6 +40,7 @@ CAPTIONS = [
     ),
 ]
 
-st.image(
-    image=IMAGES, caption=CAPTIONS, use_container_width=True
-)
+st.title("Image Gallery")
+
+for image, caption in zip(IMAGES, CAPTIONS):
+    centered_image(image, caption=caption)

--- a/pages/Melt-Rates.py
+++ b/pages/Melt-Rates.py
@@ -1,0 +1,299 @@
+import altair as alt
+import streamlit as st
+
+from database import MELT_RATES_TABLE
+from modules.database import db_table
+from modules.melt_rates import (
+    DRAFT_LABEL,
+    MELT_RATE_LABEL,
+    SURFACE_AREA_LABEL,
+    melt_rate_observations,
+    observation_month_range,
+    raw_data_table,
+    site_summary,
+)
+from modules.styling import resample_colors
+from modules.ui_elements import GLACIER_ID_KEY, load_site_names
+
+# Cross-system melt rate comparison.
+#
+# The Statistics Dashboard answers "what happened at this one glacier?". This
+# page answers the complementary question — "how do the systems compare to each
+# other?" — so every chart here puts all selected systems on shared axes.
+
+# Single hue throughout: color on this page never encodes identity (the system
+# is already on an axis or a facet header), only magnitude. Slot-1 blue matches
+# the Statistics Dashboard so the two pages read as one product.
+BLUE = "#2a78d6"
+GRIDLINE = "#e6e8eb"
+INK_MUTED = "#5c6570"
+
+# Melt rates span roughly three orders of magnitude (0.001–3.8 m d⁻¹), and a
+# handful of fast-melting icebergs at one system set the top of that range. On a
+# linear axis those few points push every other system into a sliver against
+# zero, so the comparison charts use a log scale. Safe here because the catalog
+# holds no zero or negative melt rates. Ticks are pinned to decades so the axis
+# stays readable instead of showing Vega's default log labels.
+LOG_TICKS = [0.001, 0.01, 0.1, 1]
+
+# Month of observation gets jet, sampled into one discrete step per month.
+# Chosen for maximum hue separation between neighbouring months: single-hue and
+# perceptually-uniform ramps (viridis, plasma) both left adjacent months looking
+# alike in a scatter this dense.
+#
+# Jet's known trade-offs are live here and are why the chart does not lean on
+# color alone: it is not perceptually uniform (its cyan and yellow bands read as
+# brighter than the ordering implies, so "later in the year" is harder to judge
+# from a single dot), and it is not colorblind-safe. The click-to-isolate legend
+# below is the fallback for both.
+#
+# Stops are literal because matplotlib is not a runtime dependency of the app;
+# resample_colors interpolates them to however many months the catalog covers.
+JET_STOPS = [
+    "#000080", "#0000df", "#0028ff", "#0080ff", "#00d4ff", "#36ffc1", "#7dff7a",
+    "#c1ff36", "#ffe600", "#ff9400", "#ff4700", "#df0000", "#800000",
+]
+# Color for points filtered out by the legend selection: a light neutral that
+# stays visible as context without competing with the isolated month.
+MUTED_POINT = "#d3d7dd"
+MONTH_LABEL_EXPR = (
+    "['','Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']"
+    "[datum.value]"
+)
+
+st.title("Iceberg Melt Rates by System")
+st.markdown(
+    "Compare submarine melt rates across Greenland's glacier systems. Every "
+    "chart below shows the selected systems on shared axes, so differences "
+    "between them are read directly rather than by flipping between sites."
+)
+
+st.header("Filter", divider=True)
+
+site_options = load_site_names(db_table(MELT_RATES_TABLE))
+
+selected = st.multiselect(
+    "Glacier systems:",
+    options=site_options.to_dict("records"),
+    # Every system is selected by default: the page's purpose is the
+    # all-systems comparison, so it opens on that rather than on an empty
+    # state the reader has to assemble first.
+    default=site_options.to_dict("records"),
+    format_func=lambda option: f"{option[GLACIER_ID_KEY]} — {option['label']}",
+    placeholder="Select one or more glacier systems",
+)
+
+if not selected:
+    st.info("Select at least one glacier system to see melt rate comparisons.")
+    st.stop()
+
+site_ids = tuple(option[GLACIER_ID_KEY] for option in selected)
+observations = melt_rate_observations(site_ids)
+
+if observations.empty:
+    st.warning("No melt rate records found for the selected systems.")
+    st.stop()
+
+summary = site_summary(observations)
+# Rank order is computed once and reused as the explicit sort for the
+# distribution chart, so the axis order always matches the ranking in the
+# summary table.
+rank_order = summary["label"].tolist()
+ranked_observations = observations.merge(summary[["site_id", "label"]], on="site_id")
+
+st.header("Overview", divider=True)
+overview = st.columns(4)
+overview[0].metric("Systems", f"{len(summary)}")
+overview[1].metric("Iceberg observations", f"{len(observations):,}")
+overview[2].metric(
+    "Median melt rate", f"{observations['melt_rate'].median():.2f} m d⁻¹"
+)
+overview[3].metric(
+    "Observation span",
+    f"{observations['start'].min():%Y}–{observations['end'].max():%Y}",
+)
+
+st.header("Melt Rate Distribution by System", divider=True)
+st.caption(
+    "Systems are ranked by median melt rate. The box spans the interquartile "
+    "range, the whiskers reach 1.5× that range, and points beyond them are "
+    "individual icebergs. Sample sizes vary widely between systems, so each "
+    "label carries its observation count."
+)
+
+distribution = (
+    alt.Chart(ranked_observations)
+    .mark_boxplot(
+        size=11,
+        median=alt.MarkConfig(color="white", strokeWidth=1.5),
+        outliers=alt.MarkConfig(color=BLUE, filled=True, opacity=0.45, size=18),
+        rule=alt.MarkConfig(color=INK_MUTED, size=1),
+    )
+    .encode(
+        y=alt.Y("label:N", sort=rank_order, title=None),
+        x=alt.X(
+            "melt_rate:Q",
+            title=f"{MELT_RATE_LABEL}, log scale",
+            scale=alt.Scale(type="log"),
+            axis=alt.Axis(gridColor=GRIDLINE, values=LOG_TICKS, format=".3~f"),
+        ),
+        color=alt.value(BLUE),
+    )
+    # ~24px per system keeps the boxes from collapsing into each other when
+    # all systems are selected, and keeps the chart compact when only a few are.
+    .properties(height=max(180, 24 * len(summary)))
+    .configure_axis(labelFontSize=11, titleFontSize=12, domainColor=GRIDLINE, tickColor=GRIDLINE)
+    .configure_view(strokeWidth=0)
+)
+st.altair_chart(distribution, use_container_width=True)
+
+with st.expander("Ranked summary table"):
+    st.dataframe(
+        summary[["site_id", "site", "observations", "median", "mean"]].rename(
+            columns={
+                "site_id": "Site ID",
+                "site": "Glacier System",
+                "observations": "Observations",
+                "median": f"Median {MELT_RATE_LABEL.lower()}",
+                "mean": f"Mean {MELT_RATE_LABEL.lower()}",
+            }
+        ),
+        use_container_width=True,
+        hide_index=True,
+    )
+
+st.header("Melt Rate vs. Draft", divider=True)
+st.caption(
+    "Each point is one iceberg observation window, colored by the month the "
+    "window opened. **Click a month in the legend to isolate it** — shift-click "
+    "to compare several, click empty space to reset."
+)
+
+first_month, last_month = observation_month_range()
+observed_months = list(range(first_month, last_month + 1))
+month_colors = resample_colors(JET_STOPS, len(observed_months))
+
+# Clicking a month in the legend isolates it; shift-click builds up a set, and
+# clicking empty space clears back to all months. Nine ordered colors can only
+# be told apart so far in a scatter this dense, so this carries the part of the
+# job the ramp cannot.
+month_selection = alt.selection_point(fields=["month"], bind="legend")
+
+scatter = (
+    alt.Chart(observations)
+    .mark_circle(size=45, stroke="white", strokeWidth=0.4)
+    .encode(
+        x=alt.X(
+            "draft:Q",
+            title=DRAFT_LABEL,
+            axis=alt.Axis(gridColor=GRIDLINE, tickCount=10),
+        ),
+        y=alt.Y(
+            "melt_rate:Q",
+            title=f"{MELT_RATE_LABEL}, log scale",
+            scale=alt.Scale(type="log"),
+            axis=alt.Axis(gridColor=GRIDLINE, values=LOG_TICKS, format=".3~f"),
+        ),
+        color=alt.condition(
+            month_selection,
+            alt.Color(
+                # Ordinal, not quantitative: a discrete swatch per month is far
+                # easier to match back to a dot than a continuous gradient bar.
+                "month:O",
+                # The domain spans the whole catalog's months (see
+                # observation_month_range) rather than the current selection, so
+                # a given month keeps its color no matter which systems are
+                # filtered in — and the scheme is resampled to that span.
+                scale=alt.Scale(domain=observed_months, range=month_colors),
+                legend=alt.Legend(
+                    # Short title: the full "Month of observation" clips against
+                    # the chart container's right edge, and the caption above
+                    # already says what the color means.
+                    title="Month",
+                    labelExpr=MONTH_LABEL_EXPR,
+                    symbolType="circle",
+                    symbolSize=110,
+                ),
+            ),
+            alt.value(MUTED_POINT),
+        ),
+        opacity=alt.condition(month_selection, alt.value(0.8), alt.value(0.3)),
+        tooltip=[
+            alt.Tooltip("site_id:N", title="Site"),
+            alt.Tooltip("site:N", title="System"),
+            alt.Tooltip("start:T", title="Observation start", format="%m/%d/%Y"),
+            alt.Tooltip("start:T", title="Month", format="%B"),
+            alt.Tooltip("melt_rate:Q", title=MELT_RATE_LABEL, format=".2f"),
+            alt.Tooltip("draft:Q", title=DRAFT_LABEL, format=".1f"),
+            alt.Tooltip("surface_area:Q", title=SURFACE_AREA_LABEL, format=",.0f"),
+        ],
+    )
+    .add_params(month_selection)
+    .properties(height=380)
+    .configure_axis(labelFontSize=11, titleFontSize=12, domainColor=GRIDLINE, tickColor=GRIDLINE)
+    .configure_view(strokeWidth=0)
+)
+st.altair_chart(scatter, use_container_width=True)
+
+st.header("Melt Rate Through Time", divider=True)
+st.caption(
+    "One panel per system, sharing a log melt-rate axis (m d⁻¹) so panels are "
+    "comparable at a glance. Each point is an observation window; a sparse "
+    "panel means limited imagery coverage at that system, not slow melt."
+)
+
+timeline = (
+    alt.Chart(ranked_observations)
+    .mark_circle(size=28, opacity=0.6, color=BLUE)
+    .encode(
+        x=alt.X(
+            "start:T",
+            title=None,
+            axis=alt.Axis(format="%Y", labelAngle=-45, gridColor=GRIDLINE, tickCount=3),
+        ),
+        y=alt.Y(
+            "melt_rate:Q",
+            # Titled in the caption instead of on the axis: Vega repeats an
+            # axis title once per facet row, where it crowds and clips against
+            # the panel to its left.
+            title=None,
+            scale=alt.Scale(type="log"),
+            axis=alt.Axis(gridColor=GRIDLINE, values=LOG_TICKS, format=".3~f"),
+        ),
+        tooltip=[
+            alt.Tooltip("site_id:N", title="Site"),
+            alt.Tooltip("start:T", title="Observation start", format="%m/%d/%Y"),
+            alt.Tooltip("end:T", title="Observation end", format="%m/%d/%Y"),
+            alt.Tooltip("melt_rate:Q", title=MELT_RATE_LABEL, format=".2f"),
+        ],
+    )
+    .properties(width=200, height=110)
+    .facet(
+        # Faceted rather than 29 colored lines on one axis: past a handful of
+        # series no categorical palette stays distinguishable, and the panels
+        # also make each system's temporal coverage visible.
+        facet=alt.Facet("site_id:N", title=None, sort=summary["site_id"].tolist()),
+        columns=6,
+    )
+    # An axis per panel, not one per column. The site count rarely fills the
+    # grid exactly (29 systems across 6 columns leaves the last row short), and
+    # with column-level axes the short columns draw their axis down at the
+    # grid's baseline — which reads as a phantom, dataless panel sitting in the
+    # gap. The scale stays shared, so panels remain comparable.
+    .resolve_axis(x="independent")
+    .configure_axis(labelFontSize=10, titleFontSize=11, domainColor=GRIDLINE, tickColor=GRIDLINE)
+    .configure_view(strokeWidth=0)
+    .configure_header(labelFontSize=11, labelFontWeight="bold")
+)
+st.altair_chart(timeline, use_container_width=True)
+
+st.header("Raw Data", divider=True)
+data = raw_data_table(observations)
+st.dataframe(data, height=250, use_container_width=True, hide_index=True)
+st.download_button(
+    label="Download .csv file",
+    help="Download the above shown data as a .csv file",
+    data=data.to_csv(index=False),
+    file_name="iceberg_melt_rates_by_system.csv",
+    mime="text/csv",
+)

--- a/pages/Research-methods.py
+++ b/pages/Research-methods.py
@@ -1,57 +1,77 @@
 import streamlit as st
-
-
-
-st.title('ICE-AGE Research Methods')
-st.markdown('This page will describe the flow and methods to __________')
-
-st.sidebar.title("Customize Map Appearance")
-map_style = st.sidebar.selectbox(
-    "Select Map Style", 
-    options=["CartoDB positron", "CartoDB dark_matter"],
-    index=0  # Default style: CartoDB positron
-)
-
-st.sidebar.image("catalog-data/images/Calving.png", caption = "An iceberg towers above the waters of Ilulissat Icefjord, after calving off of Sermeq Kujalleq, or Jakobshavn Glacier, in western Greenland. Credit: Allen Pope, NSIDC")
-st.sidebar.image("catalog-data/images/Boats-n-icebergs.png", caption= "A scientific research vessel churns through the coastal waters of western Greenland, leaving an open path through small icebergs and bergy bits. Instruments deployed in the region help researchers to better understand ocean conditions and how narwhal whales use the glacial fjord environment. Credit: Twila Moon, NSIDC")
-
-
-with st.expander("How was ICE-AGE created?", expanded=True):
-    st.markdown("ICE-AGE will initially reflect results from very high-resolution satellite imagery for 2011-2023. The processing pipeline can be applied to a variety of imagery types, including ArcticDEM time-stamped DEMs.")
-    st.image("catalog-data/images/DEM-differencing.png")
-    st.info("Example of high- resolution iceberg elevation observations for melt rate estimates. Method: Enderlin & Hamilton (2014).")
-    #st.markdown("ICE-AGE is based on imagery from 2011-2023 and includes ArcticDEM time-stamped DEMs. Code is available on GitHub: [GitHub link](https://doi.org/10.5281/zenodo.8011424)")
-
-    st.markdown("Automated iceberg detection for distributions:")
-    st.image("catalog-data/images/DrJukes.png")
-    st.info("Learn more about iceberg fragmentation theory in [Enderlin et al. (2023)](https://doi.org/10.18739/A2SX64B7D).")
-
-
 from graphviz import Digraph
 
-# Create a Digraph object
+from modules.styling import centered_image
+
+st.title("ICE-AGE Research Methods")
+st.markdown(
+    "This page describes how the imagery underlying ICE-AGE is turned into the "
+    "iceberg outlines, volumes, and melt rates shown in the Iceberg Viewer and "
+    "Statistics Dashboard."
+)
+
+with st.expander("How was ICE-AGE created?", expanded=True):
+    st.markdown(
+        "ICE-AGE initially reflects results from very high-resolution satellite "
+        "imagery for 2011–2023. The processing pipeline can be applied to a "
+        "variety of imagery types, including ArcticDEM time-stamped DEMs."
+    )
+    centered_image("catalog-data/images/DEM-differencing.png")
+    st.info(
+        "Example of high-resolution iceberg elevation observations, differenced "
+        "between repeat acquisitions, used for melt rate estimates. "
+        "Method: Enderlin & Hamilton (2014)."
+    )
+
+    st.markdown("Automated iceberg detection for distributions:")
+    centered_image("catalog-data/images/DrJukes.png")
+    st.info(
+        "Learn more about iceberg fragmentation theory in "
+        "[Enderlin et al. (2023)](https://doi.org/10.18739/A2SX64B7D)."
+    )
+
+    st.markdown(
+        "Elevations for each iceberg are derived from stereo satellite image "
+        "pairs (scene 1 / scene 2 below), which are used to generate a DEM for "
+        "each acquisition date. Differencing DEMs from two dates for the same "
+        "iceberg (right) isolates the elevation change used to compute melt rate."
+    )
+    centered_image("catalog-data/images/Aman-cool-scientist.png")
+
 dot = Digraph()
+dot.attr(rankdir="TB", bgcolor="transparent", nodesep="0.35", ranksep="0.45", splines="spline")
+dot.attr(
+    "node", shape="box", style="filled,rounded", fillcolor="#EAF3FA:#CFE8F5",
+    gradientangle="90", color="#0047AB", penwidth="1.6",
+    fontname="Helvetica", fontsize="13", fontcolor="#0B2545",
+    margin="0.22,0.14",
+)
+dot.attr("edge", color="#0E7C9E", penwidth="1.8", arrowsize="0.85", arrowhead="vee")
 
-# Set the graph size (increase as needed)
-dot.attr(size='80,100')  # Adjust the size
-dot.attr(dpi='100')  # Optional: Increase resolution for better clarity
+# Labels wrap with \n so boxes grow to fit the text instead of clipping it.
+dot.node("A", "Worldview stereo images")
+dot.node("B", "DEM generation by NASA Ames\nStereo Pipeline (ASP)")
+dot.node("C", "Manual iceberg tracking")
+dot.node("D", "Differencing repeat DEMs")
+dot.node("E", "Compute volume change")
+dot.node("F", "Subtract surface melting\nfrom volume change")
+dot.node("G", "Freshwater flux from\nsubmarine melting")
+dot.node("H", "Melt rate =\nfreshwater flux / submerged area", fillcolor="#0047AB:#0E7C9E", fontcolor="white")
+dot.edges(["AB", "BC", "CD", "DE", "EF", "FG", "GH"])
 
-# Add nodes
-dot.node('A', 'Worldview stereo images', shape='rect', style='filled', fillcolor='lightblue')
-dot.node('B', 'DEMs generation by NASA Ames Stereo Pipeline (ASP)', shape='rect', style='filled', fillcolor='lightblue')
-dot.node('C', 'Manual iceberg tracking', shape='rect', style='filled', fillcolor='lightblue')
-dot.node('D', 'Differencing DEMs', shape='rect', style='filled', fillcolor='lightblue')
-dot.node('E', 'Compute Volume Change', shape='rect', style='filled', fillcolor='lightblue')
-dot.node('F', 'Subtract surface melting from volume change ', shape='rect', style='filled', fillcolor='lightblue')
-dot.node('G', 'Freshwater flux from submarine melting', shape='rect', style='filled', fillcolor='lightblue')
-dot.node('H', 'melt rate = freshwater flux / submerged area ', shape='rect', style='filled', fillcolor='lightblue')
-
-
-dot.edges(['AB', 'BC', 'CD', 'DE', 'EF', 'FG', 'GH'])
-col1 = st.container()
-with col1:
+st.header("Processing Pipeline", divider=True)
+_, flowchart_col, _ = st.columns([1, 2, 1])
+with flowchart_col:
     st.graphviz_chart(dot)
-    st.image("catalog-data/images/Aman-cool-scientist.png", caption="Woot woot", use_container_width=True)  # Replace with your image path
 
-
-st.title("Data Generation:")
+st.header("References", divider=True)
+st.markdown(
+    "- Enderlin, E. M. and Hamilton, G. S. (2014). Estimates of iceberg submarine "
+    "melting from high-resolution digital elevation models: application to Sermilik "
+    "Fjord, East Greenland. *Journal of Glaciology*, 60(224), 1084–1092. "
+    "[https://doi.org/10.3189/2014JoG14J085](https://doi.org/10.3189/2014JoG14J085)\n"
+    "- Enderlin, E. M., Friel, A., Liu, J., and Kopera, M. (2023). Greenland ice "
+    "mélange fragmentation theory curve parameters from digital elevation models "
+    "(2011–2020). NSF Arctic Data Center. "
+    "[https://doi.org/10.18739/A2SX64B7D](https://doi.org/10.18739/A2SX64B7D)"
+)

--- a/pages/Statistics-dashboard.py
+++ b/pages/Statistics-dashboard.py
@@ -1,13 +1,9 @@
+import altair as alt
 import streamlit as st
 
 from database import MELT_RATES_TABLE, SHAPE_TABLE
 from modules.database import db_table
-from modules.statistics import (
-    key_statistics,
-    key_statistics_chart_data,
-    load_statistics,
-    statistic_dates_for_site,
-)
+from modules.statistics import key_statistics, load_statistics, statistic_dates_for_site
 from modules.ui_elements import (
     date_range_selector,
     has_records,
@@ -21,7 +17,7 @@ selected_site, selected_dates = site_and_date_query_params()
 with open("pages/statistics.css", "r") as f:
     st.markdown(f"<style>{f.read()}</style>", unsafe_allow_html=True)
 
-st.title("📊 Iceberg Statistics Dashboard")
+st.title("Iceberg Statistics Dashboard")
 
 with st.container():
     col1, col2 = st.columns(2, vertical_alignment="bottom")
@@ -45,110 +41,64 @@ if site_name:
         available_dates = statistic_dates_for_site(site_name["Glacier_ID"])
         date_range = date_range_selector(available_dates, selected_dates)
 
-
-def hide_button(site_name, date, metric_name):
-    button_key = button_id(site_name, date, metric_name, True)
-    st.session_state[button_key] = True
-
-
-def button_id(site_name, date, metric_name, state=False):
-    base_name = f"{site_name}_{date}_{metric_name}"
-    if state:
-        return base_name + "_visible"
-    else:
-        return base_name
-
-
-@st.fragment
-def load_chart(site_name, date, metric_name):
-    button_key = button_id(site_name, date, metric_name, True)
-    data_loaded = st.session_state.get(button_key, False)
-
-    with st.expander("Chart"):
-        if not data_loaded:
-            if st.button(
-                    "Load Data",
-                    key=button_id(site_name, date, metric_name),
-                    type="secondary",
-                    on_click=hide_button,
-                    args=(site_name, date, metric_name),
-            ):
-                st.session_state[button_key] = True
-        else:
-            with st.spinner("Loading chart"):
-                chart_data = key_statistics_chart_data(site_name, date)
-                st.line_chart(
-                    data=chart_data[metric_name].astype("float"),
-                    y_label=metric_name,
-                    x_label="Observation #",
-                )
-
-
-def chart_container(column, site_name, row, metric_name):
-    button_key = button_id(
-        site_name["Glacier_ID"], row["Observation Start"], metric_name, True
-    )
-    st.session_state[button_key] = False
-
-    with column.container():
-        load_chart(
-            site_name["Glacier_ID"], row["Observation Start"],
-            metric_name
-        )
-
+CHART_METRICS = [
+    "Melt Rate (m d⁻¹)",
+    "Draft Mean (m)",
+    "Surface Area Mean (m²)",
+    "Volume Change (m³ d⁻¹)",
+    "Melt Rate Uncertainty",
+    "Number of Days",
+]
 
 if site_name:
+    stats = key_statistics(site_name=site_name["Glacier_ID"])
+
+    st.header("Key Iceberg Statistics", divider=True)
+    st.caption(f"{len(stats)} observation window(s) at {site_name['label']}")
+
+    chart_data = stats[["Observation Start"]].copy()
+    for metric_name in CHART_METRICS:
+        chart_data[metric_name] = stats[metric_name].astype("float")
+
+    columns = st.columns(3)
+    for index, metric_name in enumerate(CHART_METRICS):
+        with columns[index % 3]:
+            st.markdown(f"**{metric_name}**")
+            # mark_line(point=...) always draws a visible marker per
+            # observation, so single-observation-window sites (e.g. many
+            # sites only have 1 window) still show something instead of an
+            # empty-looking chart with no line to draw. The point is styled
+            # distinctly from the line (larger, contrasting color, white
+            # ring) so individual observations stand out clearly.
+            chart = (
+                alt.Chart(chart_data)
+                .mark_line(
+                    color="#2a78d6",
+                    point=alt.OverlayMarkDef(
+                        color="#eb6834", size=90, filled=True,
+                        stroke="white", strokeWidth=1.5,
+                    ),
+                )
+                .encode(
+                    x=alt.X("Observation Start", axis=alt.Axis(labelAngle=-45)),
+                    # zero=False: auto-scale to the data's own range so
+                    # real variability is visible instead of being
+                    # compressed against a y-axis anchored at 0.
+                    y=alt.Y(metric_name, scale=alt.Scale(zero=False)),
+                )
+                .properties(height=220, padding={"left": 5, "right": 5, "top": 5, "bottom": 5})
+                .configure_axis(labelFontSize=10, titleFontSize=11)
+                .configure_view(strokeWidth=0)
+            )
+            st.altair_chart(chart, use_container_width=True)
+
     loader_args = dict(site_name=site_name["Glacier_ID"])
     if date_range:
         loader_args["date"] = date_range["start"]
-
-    key_stats = key_statistics(**loader_args)
     data = load_statistics(**loader_args)
 
-    st.header("Key Iceberg Statistics")
-    for _, row in key_stats.iterrows():
-        with st.container(width="stretch", border=True):
-            with st.container(width="stretch"):
-                columns = st.columns(4)
-
-                for index, metric_name in enumerate(
-                    [
-                        "Observation Start",
-                        "Draft Mean (m)",
-                        "Melt Rate (m/day)",
-                        "Melt Rate Uncertainty",
-                    ]
-                ):
-                    if metric_name == "Observation Start":
-                        label = f":material/date_range: {metric_name}"
-                    else:
-                        label = f"_{metric_name}_"
-
-                    columns[index].metric(
-                        label=label,
-                        value=row[metric_name],
-                    )
-                    if metric_name != "Observation Start":
-                        chart_container(columns[index], site_name, row, metric_name)
-
-            with st.container(width="stretch"):
-                columns = st.columns(4)
-
-                for index, metric_name in enumerate(
-                    [
-                        "Number of Days",
-                        "Surface Area Mean (m^2)",
-                        "Volume change (m^3/day)",
-                    ]
-                ):
-                    columns[index].metric(
-                        label=f"_{metric_name}_", value=row[metric_name]
-                    )
-                    if metric_name != "Number of Days":
-                        chart_container(columns[index], site_name, row, metric_name)
-
-    st.write("## Raw data")
-    st.dataframe(data)
+    st.header("Raw Data", divider=True)
+    st.dataframe(data, height=250)
     st.download_button(
         label="Download .csv file",
         help="Download the above shown data as a .csv file",


### PR DESCRIPTION
Corrects how icebergs are identified across imagery campaigns, adds a
cross-system melt rate page, and gives the app a consistent visual treatment.

Branched before #25 and merged with it — see "Merge notes" below, which is the
part most worth reviewing.

## Data-correctness fixes

These change what the maps and statistics actually show.

- **Icebergs are keyed by `(IcebergID, filename)`.** `IcebergID` is only unique
  within a single campaign's shapefile and is reused across unrelated campaigns
  and years. Coloring, grouping, displacement lines, arrowheads and the hover
  highlight all previously conflated unrelated icebergs. A caption on the
  Iceberg Viewer explains this to users.
- **Date filtering is scoped to campaign files.** Filtering by `Date` value
  site-wide pulled rows from the wrong campaign wherever two adjacent campaigns
  share a boundary date. `map_data()` now resolves the selection to the
  campaign file(s) whose `(min, max)` range matches, then filters on `filename`.
- **Duplicate digitizations are removed.** Some shapefiles contain more than one
  digitization of the same iceberg on the same date, which made observation
  pairing and the resulting displacement distance unreliable. Now de-duplicated
  to one row per `(IcebergID, filename, Date)` with a row-number window.
- **Lines and arrows only where a displacement exists** — `shape_distances()`
  now also requires a non-null `late_centroid_geom`, so no degenerate geometry
  is constructed.
- **Deep links no longer depend on the display date format.** The display format
  changed to `%m/%d/%Y`, and URL parameters were built from displayed dates. A
  separate `URL_DATE_FORMAT` is emitted as `url_start`/`url_end` alongside the
  human-facing columns, and the date selector matches on those.
- **`clear_db_cache()` clears the map and melt-rate caches**, so contents cannot
  persist across a database reload.
- **`GLACIER_ID_KEY` is a literal**, so importing `modules/ui_elements.py` no
  longer requires a live database connection.

## New features

- **Melt Rates page** — compares submarine melt rates across all 29 glacier
  systems on shared axes, complementing the Statistics Dashboard's single-site
  view: distribution by system ranked by median, melt rate vs. draft colored by
  month with a click-to-isolate legend, a per-system timeline, and a CSV export.
  Backed by the new `modules/melt_rates.py`. Melt rates span ~3 orders of
  magnitude, so the comparison charts use a log scale.
- **Drift velocity** — `velocity_m_per_day` in the Iceberg Viewer tooltip,
  showing `N/A` where there is no next observation.
- **Directional arrowheads** on displacement lines, in a dedicated Leaflet pane
  so they stay above the polygons regardless of layer order.
- **Hover-to-highlight** — hovering an iceberg thickens its displacement line.
- **Statistics Dashboard as an always-on chart grid** — six Altair charts
  rendered directly from the loaded statistics, replacing the per-metric
  "Load Data" button machinery and the `key_statistics_chart_data()` query
  (~90 lines removed).

## Interface and content

- New `modules/styling.py`: shared typography, cards, metric tiles, framed maps.
- ESRI satellite as the default basemap; both maps fit to their data bounds
  rather than a fixed zoom.
- Real citations on Research Methods and Acknowledgements, working catalog
  download links, and placeholder text replaced throughout.
- Units rendered as m², m³ d⁻¹, m d⁻¹.

## Merge notes (#25)

#25 landed while this branch was open and reworked the database layer, so this
is an API integration rather than a textual merge:

- All queries route through `execute_query()` for the new thread lock,
  including the new `modules/melt_rates.py`.
- `db_table()`/`db_exists()` are no longer cached, so `clear_db_cache()` no
  longer clears them.
- `site_name_selector()`/`load_site_names()` take a table name rather than a
  Table object.
- `iceberg_map()` returns a feature group instead of a Map. Map construction
  (ESRI basemap, arrowhead pane, bounds fitting) moved to the page, and the
  feature group is passed via `feature_group_to_add`, keeping #25's benefit
  that switching observation periods swaps features instead of rebuilding.

**Both sides fixed the same date-selector crash.** Kept this branch's
`url_start` matching, which is independent of the display format, plus #25's
guard against a malformed `date_range` parameter. Worth a look: #25's version
tested one column (`start_date`) while filtering on another (`start`).

**The hover-highlight script needed rewriting** for the new rendering path.
streamlit-folium re-renders a feature group through `generate_leaflet_string()`,
which rewrites folium's generated variable names, so names captured at build
time no longer resolve — it now reaches its layers through
`window.feature_group`. It is also wrapped in a `MacroElement`: streamlit-folium
collects each child's Jinja `script` macro and silently skips children without
one, so as a plain `folium.Element` it never reached the page at all.

**Two breakages in the reimport path, introduced in #25, are fixed here:**

- `clear_db_cache()` called `get_connection.clear()`, but the cache decorator
  is on `connect_to_db`; `get_connection` is a plain wrapper with no `.clear()`.
- Data Import called `get_connection().disconnect()`, but `get_connection()`
  now returns a `(connection, lock)` tuple.

Both raise `AttributeError` on database re-creation. Happy to split these into
their own PR if you'd rather have them separately.

**Header emoji — please sanity-check this one.** #25 added 🔍 to the Iceberg
Viewer to match 📊 on the Statistics Dashboard, while this branch removed emoji
from headings. I kept the headers uniform, in the emoji-free direction. Easy to
flip if you prefer the emoji.

## Testing

Ran the app and walked every page. Home, Iceberg Viewer, Statistics Dashboard
and Melt Rates all render; server log is clean. The hover-highlight was
verified in the browser: hovering one iceberg thickens exactly the line
matching its `(IcebergID, filename)` and mouseout resets the rest.

Not addressed here: Streamlit logs a deprecation on every rerun —
`use_container_width` is replaced by `width='stretch'`/`width='content'`, and
its stated removal date has already passed. It affects pages beyond this
change, so it seemed better as its own PR.

## Not included

`draft/` (manuscript, figures, figure-generation script) is gitignored — paper
material rather than app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
